### PR TITLE
use child_process to start/stop a boot app

### DIFF
--- a/src/BootApp.ts
+++ b/src/BootApp.ts
@@ -1,15 +1,27 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license.
 
+import { ChildProcess } from "child_process";
+
 export const STATE_INACTIVE = 'inactive';
+export const STATE_RUNNING = 'running';
 
 export class BootApp {
+    private _process?: ChildProcess;
     constructor(
         private _path: string,
         private _name: string,
         private _classpath: ClassPathData,
         private _state: string
     ) { }
+
+    public get process(): ChildProcess | undefined {
+        return this._process;
+    }
+
+    public set process(process: ChildProcess | undefined) {
+        this._process = process;
+    }
 
     public get path(): string {
         return this._path;

--- a/src/LocalAppTree.ts
+++ b/src/LocalAppTree.ts
@@ -3,7 +3,7 @@
 
 import * as vscode from "vscode";
 import * as path from "path";
-import { BootApp } from "./BootApp";
+import { BootApp, STATE_RUNNING } from "./BootApp";
 import { BootAppManager } from "./BootAppManager";
 
 export class BootAppItem implements vscode.TreeItem {
@@ -21,7 +21,7 @@ export class BootAppItem implements vscode.TreeItem {
 
     public get iconPath(): string {
         let status: string = 'stop.svg';
-        if (this.state === "running") {
+        if (this.state === STATE_RUNNING) {
             status = 'running.svg';
         }
         return this._context.asAbsolutePath(path.join('resources', status));


### PR DESCRIPTION
See #5 

The basic idea of this PR is:
* start: spawn a process of `java -classpath <classpaths> <main class>` for a boot app.
* stop: kill the process.

Available main classes are retrieved by command `vscode.java.resolveMainClass` implemented in Java Debugger extension.

Known issue:
Without things like JMX, the Java process is killed directly instead of being shutdown by some signals.
```
2018-08-01 21:38:54.151  INFO 22512 --- [           main] o.s.b.w.embedded.tomcat.TomcatWebServer  : Tomcat started on port(s): 8080 (http) with context path ''
2018-08-01 21:38:54.151  INFO 22512 --- [           main] com.example.demo.DemoApplication         : Started DemoApplication in 2.895 seconds (JVM running for 3.379)
<============ Process killed here, following logs won't be printed.
2018-08-01 21:38:58.894  INFO 22512 --- [       Thread-3] ConfigServletWebServerApplicationContext : Closing org.springframework.boot.web.servlet.context.AnnotationConfigServletWebServerApplicationContext@7920ba90: startup date [Wed Aug 01 21:38:51 CST 2018]; root of context hierarchy
2018-08-01 21:38:58.909  INFO 22512 --- [       Thread-3] o.s.j.e.a.AnnotationMBeanExporter        : Unregistering JMX-exposed beans on shutdown
```