### PR TITLE
Fix empty QuickPickItem for main classes.

### DIFF
--- a/src/Controller.ts
+++ b/src/Controller.ts
@@ -29,7 +29,7 @@ export class Controller {
         const mainClassList = await vscode.commands.executeCommand('java.execute.workspaceCommand', 'vscode.java.resolveMainClass', app.path);
         if (mainClassList && mainClassList instanceof Array && mainClassList.length > 0) {
             const mainClassData: MainClassData = mainClassList.length === 1 ? mainClassList[0] :
-                await vscode.window.showQuickPick(mainClassList.map(x => Object.assign({ title: x.mainClass }, x)));
+                await vscode.window.showQuickPick(mainClassList.map(x => Object.assign({ label: x.mainClass }, x)));
 
             outputChannel.clear();
             outputChannel.show();


### PR DESCRIPTION
```typescript
export interface QuickPickItem {

		/**
		 * A human readable string which is rendered prominent.
		 */
		label: string;

		/**
		 * A human readable string which is rendered less prominent.
		 */
		description?: string;

		/**
		 * A human readable string which is rendered less prominent.
		 */
		detail?: string;

		/**
		 * Optional flag indicating if this item is picked initially.
		 * (Only honored when the picker allows multiple selections.)
		 *
		 * @see [QuickPickOptions.canPickMany](#QuickPickOptions.canPickMany)
		 */
		picked?: boolean;
	}
```
This PR fixes issue #22 