### PR TITLE
Create launch.json in corresponding workspaceFolder if not exists.

### DIFF
--- a/src/Controller.ts
+++ b/src/Controller.ts
@@ -175,7 +175,7 @@ export class Controller {
         const launchConfigurations: vscode.WorkspaceConfiguration = vscode.workspace.getConfiguration("launch", vscode.Uri.file(mainClasData.filePath));
         const configs: vscode.DebugConfiguration[] = launchConfigurations.configurations;
         configs.push(newConfig);
-        await launchConfigurations.update("configurations", configs);
+        await launchConfigurations.update("configurations", configs, vscode.ConfigurationTarget.WorkspaceFolder);
         return newConfig;
     }
 }


### PR DESCRIPTION
When you click "start" on a boot app, if there's no launch.json in workspace, it creates a default config to run, and is supposed to save the config into launch.json file. 

#### Current behavior
The case is, when you have a workspace with multiple root folder, no launch.json file will be created, the config is updated into "Workspace Settings" instead. 
E.g. 
![image](https://user-images.githubusercontent.com/2351748/45256323-663df380-b3c7-11e8-966a-ffa8793aa239.png)
![image](https://user-images.githubusercontent.com/2351748/45256388-6c809f80-b3c8-11e8-94ac-3e09f7f50781.png)

#### What this PR does
This PR ensures the config to be updated in corresponding "WorkspaceFolder", that is a launch.json file in the corresponding root folder.  
