### PR TITLE
hide explorer for non-java workspaces

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,10 @@
             "explorer": [
                 {
                     "id": "spring-boot-dashboard",
-                    "name": "Spring-Boot Dashboard"
+                    "name": "Spring Boot Dashboard",
+                    "when": "java:serverMode",
+                    "contextualTitle": "Java",
+                    "icon": "resources/logo.png"
                 }
             ]
         },
@@ -37,7 +40,7 @@
             {
                 "command": "spring-boot-dashboard.refresh",
                 "title": "Refresh",
-                "category": "Spring-Boot Dashboard",
+                "category": "Spring Boot Dashboard",
                 "icon": {
                     "light": "resources/light/refresh.svg",
                     "dark": "resources/dark/refresh.svg"
@@ -46,27 +49,27 @@
             {
                 "command": "spring-boot-dashboard.localapp.start",
                 "title": "Start",
-                "category": "Spring-Boot Dashboard"
+                "category": "Spring Boot Dashboard"
             },
             {
                 "command": "spring-boot-dashboard.localapp.stop",
                 "title": "Stop",
-                "category": "Spring-Boot Dashboard"
+                "category": "Spring Boot Dashboard"
             },
             {
                 "command": "spring-boot-dashboard.localapp.open",
                 "title": "Open In Browser",
-                "category": "Spring-Boot Dashboard"
+                "category": "Spring Boot Dashboard"
             },
             {
                 "command": "spring-boot-dashboard.localapp.debug",
                 "title": "Debug",
-                "category": "Spring-Boot Dashboard"
+                "category": "Spring Boot Dashboard"
             },
             {
                 "command": "spring-boot-dashboard.localapp.start-multiple",
                 "title": "Start ...",
-                "category": "Spring-Boot Dashboard",
+                "category": "Spring Boot Dashboard",
                 "icon": {
                     "light": "resources/light/start.svg",
                     "dark": "resources/dark/start.svg"
@@ -75,7 +78,7 @@
             {
                 "command": "spring-boot-dashboard.localapp.debug-multiple",
                 "title": "Debug ...",
-                "category": "Spring-Boot Dashboard"
+                "category": "Spring Boot Dashboard"
             }
         ],
         "menus": {


### PR DESCRIPTION
Context varible `java:serverMode` indicates status of Java language server (from `vscode.java` extension). We hide the explorer for non-Java workspaces.

Meanwhile, as VS Code now supports more flexible layout, `conceptualContext` and `icon` are added for the explorer. see below:
![image](https://user-images.githubusercontent.com/2351748/100691500-d2034100-33c3-11eb-9db4-52a564cb9949.png)
