### PR TITLE
Changing command names from "Start" to "Run" in favor of UX

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,8 +47,8 @@
                 "icon": "$(refresh)"
             },
             {
-                "command": "spring-boot-dashboard.localapp.start",
-                "title": "Start",
+                "command": "spring-boot-dashboard.localapp.run",
+                "title": "Run",
                 "category": "Spring Boot Dashboard",
                 "icon": "$(play)"
             },
@@ -71,8 +71,8 @@
                 "icon": "$(debug-alt-small)"
             },
             {
-                "command": "spring-boot-dashboard.localapp.start-multiple",
-                "title": "Start ...",
+                "command": "spring-boot-dashboard.localapp.run-multiple",
+                "title": "Run ...",
                 "category": "Spring Boot Dashboard",
                 "icon": "$(run-all)"
             },
@@ -86,7 +86,7 @@
         "menus": {
             "commandPalette": [
                 {
-                    "command": "spring-boot-dashboard.localapp.start",
+                    "command": "spring-boot-dashboard.localapp.run",
                     "when": "never"
                 },
                 {
@@ -108,7 +108,7 @@
             ],
             "view/title": [
                 {
-                    "command": "spring-boot-dashboard.localapp.start-multiple",
+                    "command": "spring-boot-dashboard.localapp.run-multiple",
                     "when": "view == spring-boot-dashboard",
                     "group": "navigation@2"
                 },
@@ -120,7 +120,7 @@
             ],
             "view/item/context": [
                 {
-                    "command": "spring-boot-dashboard.localapp.start",
+                    "command": "spring-boot-dashboard.localapp.run",
                     "when": "view == spring-boot-dashboard && viewItem == BootApp_inactive",
                     "group": "action@5"
                 },
@@ -140,7 +140,7 @@
                     "group": "action@a"
                 },
                 {
-                    "command": "spring-boot-dashboard.localapp.start",
+                    "command": "spring-boot-dashboard.localapp.run",
                     "when": "view == spring-boot-dashboard && viewItem == BootApp_inactive",
                     "group": "inline@5"
                 },
@@ -160,7 +160,7 @@
                     "group": "inline@a"
                 },
                 {
-                    "command": "spring-boot-dashboard.localapp.start-multiple",
+                    "command": "spring-boot-dashboard.localapp.run-multiple",
                     "when": "view == spring-boot-dashboard && !viewItem",
                     "group": "action@11"
                 },

--- a/src/Controller.ts
+++ b/src/Controller.ts
@@ -24,23 +24,23 @@ export class Controller {
         return this._manager.getAppList();
     }
 
-    public async startBootApps(debug?: boolean) {
+    public async runBootApps(debug?: boolean) {
         const appList = this.getAppList();
         if (appList.length === 1 && appList[0].state !== AppState.RUNNING) {
-            this.startBootApp(appList[0], debug);
+            this.runBootApp(appList[0], debug);
         } else {
-            const appsToStart = await vscode.window.showQuickPick(
+            const appsToRun = await vscode.window.showQuickPick(
                 appList.filter(app => app.state !== AppState.RUNNING).map(app => ({ label: app.name, path: app.path })), /** items */
-                { canPickMany: true, placeHolder: `Select apps to ${debug ? "debug" : "start"}.` } /** options */
+                { canPickMany: true, placeHolder: `Select apps to ${debug ? "debug" : "run"}.` } /** options */
             );
-            if (appsToStart !== undefined) {
-                const appPaths = appsToStart.map(elem => elem.path);
-                await Promise.all(appList.filter(app => appPaths.indexOf(app.path) > -1).map(app => this.startBootApp(app, debug)));
+            if (appsToRun !== undefined) {
+                const appPaths = appsToRun.map(elem => elem.path);
+                await Promise.all(appList.filter(app => appPaths.indexOf(app.path) > -1).map(app => this.runBootApp(app, debug)));
             }
         }
     }
 
-    public async startBootApp(app: BootApp, debug?: boolean): Promise<void> {
+    public async runBootApp(app: BootApp, debug?: boolean): Promise<void> {
         const mainClasData = await vscode.window.withProgress(
             { location: vscode.ProgressLocation.Window, title: `Resolving main classes for ${app.name}...` },
             () => { return this._getMainClass(app); }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -25,11 +25,11 @@ export async function initializeExtension(_oprationId: string, context: vscode.E
     context.subscriptions.push(instrumentAndRegisterCommand("spring-boot-dashboard.refresh", () => {
         localAppManager.fireDidChangeApps();
     }));
-    context.subscriptions.push(instrumentAndRegisterCommand("spring-boot-dashboard.localapp.start", async (app: BootApp) => {
-        await controller.startBootApp(app);
+    context.subscriptions.push(instrumentAndRegisterCommand("spring-boot-dashboard.localapp.run", async (app: BootApp) => {
+        await controller.runBootApp(app);
     }));
     context.subscriptions.push(instrumentAndRegisterCommand("spring-boot-dashboard.localapp.debug", async (app: BootApp) => {
-        await controller.startBootApp(app, true);
+        await controller.runBootApp(app, true);
     }));
     context.subscriptions.push(instrumentAndRegisterCommand("spring-boot-dashboard.localapp.stop", async (app: BootApp) => {
         await controller.stopBootApp(app);
@@ -37,11 +37,11 @@ export async function initializeExtension(_oprationId: string, context: vscode.E
     context.subscriptions.push(instrumentAndRegisterCommand("spring-boot-dashboard.localapp.open", async (app: BootApp) => {
         await controller.openBootApp(app);
     }));
-    context.subscriptions.push(instrumentAndRegisterCommand("spring-boot-dashboard.localapp.start-multiple", async () => {
-        await controller.startBootApps();
+    context.subscriptions.push(instrumentAndRegisterCommand("spring-boot-dashboard.localapp.run-multiple", async () => {
+        await controller.runBootApps();
     }));
     context.subscriptions.push(instrumentAndRegisterCommand("spring-boot-dashboard.localapp.debug-multiple", async () => {
-        await controller.startBootApps(true);
+        await controller.runBootApps(true);
     }));
     vscode.debug.onDidStartDebugSession((session: vscode.DebugSession) => {
         if (session.type === "java") {


### PR DESCRIPTION
To keep code readability on a good level, not only did I change the commands naming, but also the internal functions, so it's easier to track down the methods in codebase.

Closes #153 