### PR TITLE
Allow opening apps in VS Code's integrated browser as well

### DIFF
--- a/package.json
+++ b/package.json
@@ -170,6 +170,25 @@
                     "group": "action@12"
                 }
             ]
+        },
+        "configuration": {
+            "title": "Spring Boot Dashboard",
+            "properties": {
+                "spring.dashboard.openWith": {
+                    "default": "integrated",
+                    "type": "string",
+                    "enum": [
+                        "integrated",
+                        "external"
+                    ],
+                    "enumDescriptions": [
+                        "VS Code's integrated browser",
+                        "External default browser"
+                    ],
+                    "scope": "window",
+                    "description": "Defines which browser to use when opening Spring Boot apps."
+                }
+            }
         }
     },
     "scripts": {

--- a/src/Controller.ts
+++ b/src/Controller.ts
@@ -132,7 +132,10 @@ export class Controller {
                 );
                 let port = javaProcess.stdout ? parseInt(await readAll(javaProcess.stdout)) : 0;
                 if (port > 0) {
-                    vscode.commands.executeCommand("vscode.open", vscode.Uri.parse(`http://localhost:${port}/`));
+                    const openWithExternalBrowser: boolean = vscode.workspace.getConfiguration("spring.dashboard").get("openWith") === "external";
+                    const browserCommand: string = openWithExternalBrowser ? "vscode.open" : "simpleBrowser.api.open";
+                    
+                    vscode.commands.executeCommand(browserCommand, vscode.Uri.parse(`http://localhost:${port}/`));
                 } else {
                     if (javaProcess.stderr) {
                         let err = await readAll(javaProcess.stderr);


### PR DESCRIPTION
Introduced new setting `spring.dashboard.openWith` to control where the Spring Boot app should be opened. Possible values are Integrated Browser and External (previous behavior).

As specified by @Eskibear, by default the apps will open on Integrated Browser.

Closes #154