### PR TITLE
adopt upstream API change

### DIFF
--- a/src/controllers/LiveDataController.ts
+++ b/src/controllers/LiveDataController.ts
@@ -1,5 +1,6 @@
 import { AppState } from "../BootApp";
 import { getBeans, getContextPath, getMainClass, getMappings, getPid, getPort, initialize, stsApi } from "../models/stsApi";
+import { LocalLiveProcess } from "../types/sts-api";
 import { isAlive } from "../utils";
 import { appsProvider } from "../views/apps";
 import { beansProvider } from "../views/beans";
@@ -22,33 +23,60 @@ export async function init() {
     stsApi.onDidLiveProcessUpdate(updateProcessInfo);
 }
 
-async function updateProcessInfo(processKey: string) {
+async function updateProcessInfo(payload: string | LocalLiveProcess) {
+    const liveProcess = await parsePayload(payload);
+    const { processKey, processName, pid } = liveProcess;
+
     const beans = await getBeans(processKey);
-    beansProvider.refresh(processKey, beans);
+    beansProvider.refresh(liveProcess, beans);
 
     const mappings = await getMappings(processKey);
-    mappingsProvider.refresh(processKey, mappings);
+    mappingsProvider.refresh(liveProcess, mappings);
 
     const port = await getPort(processKey);
     const contextPath = await getContextPath(processKey);
-    store.data.set(processKey, { beans, mappings, port });
-    const runningApp = appsProvider.manager.getAppByMainClass(getMainClass(processKey));
+    store.data.set(processKey, { processName, pid, beans, mappings, port });
+    const runningApp = appsProvider.manager.getAppByMainClass(processName);
     if (runningApp) {
-        runningApp.pid = parseInt(getPid(processKey));
+        runningApp.pid = parseInt(pid);
         runningApp.port = parseInt(port);
         runningApp.contextPath = contextPath;
         runningApp.state = AppState.RUNNING; // will refresh tree item
     }
 }
 
-async function resetProcessInfo(processKey: string) {
-    store.data.delete(processKey);
-    beansProvider.refresh(processKey, undefined);
-    mappingsProvider.refresh(processKey, undefined);
+async function resetProcessInfo(payload: string | LocalLiveProcess) {
+    const liveProcess = await parsePayload(payload);
+    store.data.delete(liveProcess.processKey);
+    beansProvider.refresh(liveProcess, undefined);
+    mappingsProvider.refresh(liveProcess, undefined);
 
-    const disconnectedApp = appsProvider.manager.getAppByMainClass(getMainClass(processKey));
+    const disconnectedApp = appsProvider.manager.getAppByMainClass(liveProcess.processName);
     // Workaound for: app is still running if manually disconnect from live process connection.
     if (disconnectedApp && !await isAlive(disconnectedApp.pid)) {
         disconnectedApp.reset();
+    }
+}
+
+/**
+ *
+ * Fix complatibility of lower versions.
+ *
+ * @param payload string for v1.33, LocalLiveProcess for v1.34
+ * @returns
+ */
+async function parsePayload(payload: string | LocalLiveProcess): Promise<LocalLiveProcess> {
+    if (typeof payload === "string") {
+        const processKey = payload;
+        const processName = getMainClass(processKey);
+        const pid = getPid(processKey);
+        return {
+            type: "local",
+            processKey,
+            processName,
+            pid
+        };
+    } else {
+        return payload;
     }
 }

--- a/src/controllers/LiveDataController.ts
+++ b/src/controllers/LiveDataController.ts
@@ -68,7 +68,7 @@ async function resetProcessInfo(payload: string | LocalLiveProcess) {
 async function parsePayload(payload: string | LocalLiveProcess): Promise<LocalLiveProcess> {
     if (typeof payload === "string") {
         const processKey = payload;
-        const processName = getMainClass(processKey);
+        const processName = await getMainClass(processKey);
         const pid = getPid(processKey);
         return {
             type: "local",

--- a/src/models/liveProcess.ts
+++ b/src/models/liveProcess.ts
@@ -1,16 +1,20 @@
+import { LocalLiveProcess } from "../types/sts-api";
 import { appsProvider } from "../views/apps";
-import { getPid, getMainClass } from "./stsApi";
 
 
 export class LiveProcess {
-    constructor(public processKey: string) { }
+    constructor(private liveProcess: LocalLiveProcess) { }
+
+    public get processKey(): string {
+        return this.liveProcess.processKey;
+    }
 
     public get pid(): string {
-        return getPid(this.processKey);
+        return this.liveProcess.pid;
     }
 
     public get appName(): string {
-        const mainClass = getMainClass(this.processKey);
+        const mainClass = this.liveProcess.processName;
         const runningApp = appsProvider.manager.getAppByMainClass(mainClass);
         return runningApp?.name ?? mainClass;
     }

--- a/src/models/stsApi.ts
+++ b/src/models/stsApi.ts
@@ -51,10 +51,24 @@ export async function getContextPath(processKey: string) {
     return result;
 }
 
+/**
+ * below are workaround for spring-tools v1.33 as `processKey` equals to `pid`.
+ */
 export function getPid(processKey: string) {
     return processKey.split(" - ")?.[0];
 }
 
 export function getMainClass(processKey: string) {
-    return processKey.split(" - ")?.[1];
+    const mainClass = processKey.split(" - ")?.[1];
+    if (!mainClass) {
+        const pid = getPid(processKey);
+        return getMainClassFromPid(pid);
+    }
+    return mainClass;
+}
+
+function getMainClassFromPid(pid: string) {
+    // workaround: parse output from  `jps -l`
+    // TODO
+    return pid;
 }

--- a/src/types/sts-api.d.ts
+++ b/src/types/sts-api.d.ts
@@ -7,29 +7,29 @@ export interface ExtensionAPI {
     /**
      * An event which fires on live process is connected. Payload is processKey.
      */
-    readonly onDidLiveProcessConnect: Event<string>;
+    readonly onDidLiveProcessConnect: Event<LiveProcess | string>
 
     /**
      * An event which fires on live process is disconnected. Payload is processKey.
      */
-    readonly onDidLiveProcessDisconnect: Event<string>;
+    readonly onDidLiveProcessDisconnect: Event<LiveProcess | string>
 
 	/**
      * An event which fires on live process data change. Payload is processKey.
      */
-	readonly onDidLiveProcessUpdate: Event<string>;
+	readonly onDidLiveProcessUpdate: Event<LiveProcess | string>
 
     /**
      * A command to get live process data.
      */
-    readonly getLiveProcessData: (query: SimpleQuery | BeansQuery) => Promise<any>;
+    readonly getLiveProcessData: (query: SimpleQuery | BeansQuery) => Promise<any>
 
     /**
      * A command to list all currently connected processes.
      *
      * Returns a list of processKeys.
      */
-    readonly listConnectedProcesses: () => Promise<string[]>;
+    readonly listConnectedProcesses: () => Promise<(LiveProcess | string)[]>
 }
 
 interface LiveProcessDataQuery {
@@ -50,4 +50,22 @@ interface BeansQuery extends LiveProcessDataQuery {
      */
     beanName?: string;
     dependingOn?: string;
+}
+
+/**
+ * Common information provided by all live process notifications, for all types
+ * of events and for all types of processes.
+ */
+export interface LiveProcess {
+	type: string;
+	processKey: string;
+	processName: string;
+}
+
+/**
+ * Specialized interface for type 'local' LiveProcess.
+ */
+export interface LocalLiveProcess extends LiveProcess {
+	type: "local"
+	pid: string
 }

--- a/src/types/sts-api.d.ts
+++ b/src/types/sts-api.d.ts
@@ -7,29 +7,29 @@ export interface ExtensionAPI {
     /**
      * An event which fires on live process is connected. Payload is processKey.
      */
-    readonly onDidLiveProcessConnect: Event<LiveProcess | string>
+    readonly onDidLiveProcessConnect: Event<LiveProcess | string>;
 
     /**
      * An event which fires on live process is disconnected. Payload is processKey.
      */
-    readonly onDidLiveProcessDisconnect: Event<LiveProcess | string>
+    readonly onDidLiveProcessDisconnect: Event<LiveProcess | string>;
 
 	/**
      * An event which fires on live process data change. Payload is processKey.
      */
-	readonly onDidLiveProcessUpdate: Event<LiveProcess | string>
+	readonly onDidLiveProcessUpdate: Event<LiveProcess | string>;
 
     /**
      * A command to get live process data.
      */
-    readonly getLiveProcessData: (query: SimpleQuery | BeansQuery) => Promise<any>
+    readonly getLiveProcessData: (query: SimpleQuery | BeansQuery) => Promise<any>;
 
     /**
      * A command to list all currently connected processes.
      *
      * Returns a list of processKeys.
      */
-    readonly listConnectedProcesses: () => Promise<(LiveProcess | string)[]>
+    readonly listConnectedProcesses: () => Promise<(LiveProcess | string)[]>;
 }
 
 interface LiveProcessDataQuery {
@@ -66,6 +66,6 @@ export interface LiveProcess {
  * Specialized interface for type 'local' LiveProcess.
  */
 export interface LocalLiveProcess extends LiveProcess {
-	type: "local"
-	pid: string
+	type: "local";
+	pid: string;
 }

--- a/src/views/beans.ts
+++ b/src/views/beans.ts
@@ -3,6 +3,7 @@
 
 import * as vscode from "vscode";
 import { LiveProcess } from "../models/liveProcess";
+import { LocalLiveProcess } from "../types/sts-api";
 
 interface Bean {
     processKey: string;
@@ -65,17 +66,17 @@ class BeansDataProvider implements vscode.TreeDataProvider<Bean | LiveProcess> {
         return undefined;
     }
 
-    public refresh(processKey: string, beanIds: string[] | undefined) {
+    public refresh(liveProcess: LocalLiveProcess, beanIds: string[] | undefined) {
         if (beanIds === undefined) {
             // remove
-            const targetLiveProcess = Array.from(this.store.keys()).find(lp => lp.processKey === processKey);
+            const targetLiveProcess = Array.from(this.store.keys()).find(lp => lp.processKey === liveProcess.processKey);
             if (targetLiveProcess) {
                 this.store.delete(targetLiveProcess);
             }
         } else {
             // add/update
-            const targetLiveProcess = Array.from(this.store.keys()).find(lp => lp.processKey === processKey) ?? new LiveProcess(processKey);
-            const beans = beanIds.map(b => { return { processKey, id: b }; }).sort((a, b) => a.id.localeCompare(b.id));
+            const targetLiveProcess = Array.from(this.store.keys()).find(lp => lp.processKey === liveProcess.processKey) ?? new LiveProcess(liveProcess);
+            const beans = beanIds.map(b => { return { processKey: liveProcess.processKey, id: b }; }).sort((a, b) => a.id.localeCompare(b.id));
             this.store.set(targetLiveProcess, beans);
         }
         this.onDidRefreshBeans.fire(undefined);

--- a/src/views/mappings.ts
+++ b/src/views/mappings.ts
@@ -5,7 +5,7 @@
 import * as vscode from "vscode";
 import { LiveProcess } from "../models/liveProcess";
 import { getContextPath, getPort } from "../models/stsApi";
-
+import { LocalLiveProcess } from "../types/sts-api";
 
 interface Endpoint {
     // raw
@@ -77,17 +77,17 @@ class MappingsDataProvider implements vscode.TreeDataProvider<Endpoint | LivePro
         return undefined;
     }
 
-    public refresh(processKey: string, mappingsRaw: any[] | undefined) {
+    public refresh(liveProcess: LocalLiveProcess, mappingsRaw: any[] | undefined) {
         if (mappingsRaw === undefined) {
             // remove
-            const targetLiveProcess = Array.from(this.store.keys()).find(lp => lp.processKey === processKey);
+            const targetLiveProcess = Array.from(this.store.keys()).find(lp => lp.processKey === liveProcess.processKey);
             if (targetLiveProcess) {
                 this.store.delete(targetLiveProcess);
             }
         } else {
             // add / update
-            const targetLiveProcess = Array.from(this.store.keys()).find(lp => lp.processKey === processKey) ?? new LiveProcess(processKey);
-            const mappings = mappingsRaw.map(raw => parseMapping(raw, processKey)).sort((a, b) => a.label.localeCompare(b.label));
+            const targetLiveProcess = Array.from(this.store.keys()).find(lp => lp.processKey === liveProcess.processKey) ?? new LiveProcess(liveProcess);
+            const mappings = mappingsRaw.map(raw => parseMapping(raw, liveProcess.processKey)).sort((a, b) => a.label.localeCompare(b.label));
             this.store.set(targetLiveProcess, mappings);
         }
         this.onDidRefreshMappings.fire(undefined);


### PR DESCRIPTION
In spring-tools extension v1.33, format of `processKey` changes. A regression is introduced because we wrongly depend on that to parse process name and pid.

Now in latest change (unreleased), upstream API has been reshaped to explicitly carry processName and pid. This PR does the corresponding change to adopt the API.

Note that for v1.33 where we only receive pid from upstream notification, `processName` is deducted from `jps -l` as a workaround.