### PR TITLE
can navigate to bean definition

### DIFF
--- a/package.json
+++ b/package.json
@@ -122,6 +122,12 @@
                 "title": "Open",
                 "category": "Spring Boot Dashboard",
                 "icon": "$(globe)"
+            },
+            {
+                "command": "spring.dashboard.bean.open",
+                "title": "Open",
+                "category": "Spring Boot Dashboard",
+                "icon": "$(go-to-file)"
             }
         ],
         "menus": {
@@ -237,6 +243,11 @@
                 {
                     "command": "spring.dashboard.endpoint.open",
                     "when": "view == spring.mappings && viewItem =~ /spring:endpoint(?=.*?\\b\\+GET\\b)/",
+                    "group": "inline@5"
+                },
+                {
+                    "command": "spring.dashboard.bean.open",
+                    "when": "view == spring.beans && viewItem =~ /spring:bean/",
                     "group": "inline@5"
                 }
             ]

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -8,7 +8,7 @@ import { BootApp } from './BootApp';
 import { Controller } from './Controller';
 import { init as initLiveDataController } from './controllers/LiveDataController';
 import { appsProvider } from './views/apps';
-import { beansProvider } from './views/beans';
+import { beansProvider, openBeanHandler } from './views/beans';
 import { mappingsProvider, openEndpointHandler } from './views/mappings';
 
 export async function activate(context: vscode.ExtensionContext) {
@@ -60,6 +60,7 @@ export async function initializeExtension(_oprationId: string, context: vscode.E
     context.subscriptions.push(vscode.window.createTreeView('spring.mappings', { treeDataProvider: mappingsProvider, showCollapseAll: true }));
     await initLiveDataController();
     context.subscriptions.push(instrumentOperationAsVsCodeCommand("spring.dashboard.endpoint.open", openEndpointHandler));
+    context.subscriptions.push(instrumentOperationAsVsCodeCommand("spring.dashboard.bean.open", openBeanHandler));
 
     // console.log
     context.subscriptions.push(vscode.commands.registerCommand("_spring.console.log", console.log));

--- a/src/models/stsApi.ts
+++ b/src/models/stsApi.ts
@@ -33,6 +33,15 @@ export async function getBeans(processKey: string) {
     return result;
 }
 
+export async function getBeanDetail(processKey: string, beanName: string) {
+    const bean = await stsApi.getLiveProcessData({
+        processKey,
+        endpoint: "beans",
+        beanName
+    });
+    return bean;
+}
+
 export async function getMappings(processKey: string) {
     const result = await stsApi.getLiveProcessData({
         processKey: processKey,


### PR DESCRIPTION
part of #164 

Now we simply re-use command `sts.java.javadocHoverLink` (which is registered in spring-tools) to fetch target url of a specific bean.

In the future, it would be better to implement the api in jdtls as a utility.