### PR TITLE
show static mappings before live connection is on

### DIFF
--- a/package.json
+++ b/package.json
@@ -124,6 +124,12 @@
                 "icon": "$(globe)"
             },
             {
+                "command": "spring.dashboard.endpoint.navigate",
+                "title": "Go to",
+                "category": "Spring Boot Dashboard",
+                "icon": "$(go-to-file)"
+            },
+            {
                 "command": "spring.dashboard.bean.open",
                 "title": "Open",
                 "category": "Spring Boot Dashboard",

--- a/src/BootApp.ts
+++ b/src/BootApp.ts
@@ -2,6 +2,7 @@
 // Licensed under the MIT license.
 
 import * as vscode from "vscode";
+import { requestWorkspaceSymbols } from "./models/stsApi";
 import { ClassPathData, MainClassData } from "./types/jdtls";
 import { isAlive } from "./utils";
 import { appsProvider } from "./views/apps";
@@ -22,13 +23,16 @@ export class BootApp {
     private _watchdog?: any; // used to watch running process.
 
     public mainClasses: MainClassData[];
+    public symbols: {beans: any[], mappings: any[]};
 
     constructor(
         private _path: string,
         private _name: string,
         private _classpath: ClassPathData,
         private _state: AppState,
-    ) { }
+    ) {
+        this.getWorkspaceSymbols();
+    }
 
     public get activeSessionName() : string | undefined {
         return this._activeSessionName;
@@ -142,5 +146,15 @@ export class BootApp {
         } else {
             return [];
         }
+    }
+
+    /**
+     * getWorkspaceSymbols
+     */
+    public async getWorkspaceSymbols() {
+        if (!this.symbols) {
+            this.symbols = await requestWorkspaceSymbols(this.path);
+        }
+        return this.symbols;
     }
 }

--- a/src/models/stsApi.ts
+++ b/src/models/stsApi.ts
@@ -116,3 +116,11 @@ async function getJreHome() {
     return jreHome;
 }
 
+export async function requestWorkspaceSymbols(_projectPath?: string): Promise<{
+    beans: any[],
+    mappings: any[]
+}> {
+    const beans = await stsApi.client.sendRequest("workspace/symbol", {"query": "@+"}) as any[];
+    const mappings = await stsApi.client.sendRequest("workspace/symbol", {"query": "@/"}) as any[];
+    return { beans, mappings };
+}

--- a/src/models/symbols.ts
+++ b/src/models/symbols.ts
@@ -1,0 +1,35 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license.
+
+import { requestWorkspaceSymbols } from "./stsApi";
+
+let beans: any[];
+let mappings: any[];
+
+export async function init() {
+    const symbols = await requestWorkspaceSymbols();
+    beans = symbols.beans;
+    mappings = symbols.mappings;
+}
+
+export function getBeans(projectPath?: string) {
+    if (!projectPath) {
+        return beans;
+    }
+
+    const path = sanitizeFilePath(projectPath);
+    return beans.filter(b => sanitizeFilePath(b.location.uri).startsWith(path));
+}
+
+export function getMappings(projectPath?: string) {
+    if (!projectPath) {
+        return beans;
+    }
+
+    const path = sanitizeFilePath(projectPath);
+    return mappings.filter(b => sanitizeFilePath(b.location.uri).startsWith(path));
+}
+
+function sanitizeFilePath(uri: string) {
+    return uri.replace(/^file:\/+/, "");
+}


### PR DESCRIPTION
- Static mappings are parsed from `workspace/symbol` response. (specific upstreaming API on discussion)
- TBD: click to navigate mappings