### PR TITLE
honor spring.dashboard.openUrl on opening endpoints

### DIFF
--- a/package.json
+++ b/package.json
@@ -412,7 +412,7 @@
                     "description": "Defines which browser to use when opening Spring Boot apps."
                 },
                 "spring.dashboard.openUrl": {
-                    "default": "http://localhost:{port}{contextPath}/",
+                    "default": "http://localhost:{port}{contextPath}",
                     "type": "string",
                     "scope": "window",
                     "description": "Defines which URL is opened when opening Spring Boot apps. Uses {port} and {contextPath} as placeholders."

--- a/src/Controller.ts
+++ b/src/Controller.ts
@@ -7,7 +7,7 @@ import * as path from "path";
 import * as vscode from "vscode";
 import { AppState, BootApp } from "./BootApp";
 import { BootAppManager } from "./BootAppManager";
-import { readAll } from "./utils";
+import { constructOpenUrl, readAll } from "./utils";
 import { MainClassData } from "./types/jdtls";
 const getPort = require("get-port");
 
@@ -268,18 +268,4 @@ export class Controller {
 
 function isRunInTerminal(session: vscode.DebugSession) {
     return session.configuration.noDebug === true && session.configuration.console !== "internalConsole";
-}
-
-function constructOpenUrl(contextPath: string, port: number) {
-    const configOpenUrl: string | undefined = vscode.workspace.getConfiguration("spring.dashboard").get<string>("openUrl");
-    let openUrl: string;
-
-    if (configOpenUrl === undefined) {
-        openUrl = `http://localhost:${port}${contextPath}/`;
-    } else {
-        openUrl = configOpenUrl
-            .replace("{port}", String(port))
-            .replace("{contextPath}", contextPath.toString());
-    }
-    return openUrl;
 }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -3,6 +3,7 @@
 
 import { Readable } from "stream";
 import pidtree = require("pidtree");
+import * as vscode from "vscode";
 
 export function readAll(input: Readable) : Promise<string> {
     let buffer = "";
@@ -36,4 +37,26 @@ export async function sleep(ms: number) {
             resolve();
         }, ms);
     });
+}
+
+/**
+ * Construct URL based on format defined in spring.dashboard.openUrl
+ *
+ * @param contextPath
+ * @param port
+ * @param pathSeg must starts with '/'
+ * @returns url
+ */
+export function constructOpenUrl(contextPath: string, port: number, pathSeg?: string) {
+    const configOpenUrl: string | undefined = vscode.workspace.getConfiguration("spring.dashboard").get<string>("openUrl");
+    let openUrl: string;
+
+    if (configOpenUrl === undefined) {
+        openUrl = `http://localhost:${port}${contextPath}`;
+    } else {
+        openUrl = configOpenUrl
+            .replace("{port}", String(port))
+            .replace("{contextPath}", contextPath.toString());
+    }
+    return `${openUrl}${pathSeg ?? "/"}`;
 }

--- a/src/views/mappings.ts
+++ b/src/views/mappings.ts
@@ -8,6 +8,7 @@ import { initSymbols } from "../controllers/SymbolsController";
 import { LiveProcess } from "../models/liveProcess";
 import { getContextPath, getPort } from "../models/stsApi";
 import { LocalLiveProcess } from "../types/sts-api";
+import { constructOpenUrl } from "../utils";
 
 interface Endpoint {
     // raw
@@ -201,7 +202,7 @@ export const mappingsProvider = new MappingsDataProvider();
 export async function openEndpointHandler(endpoint: Endpoint) {
     const port = await getPort(endpoint.processKey);
     const contextPath = await getContextPath(endpoint.processKey) ?? "";
-    const url = `http://localhost:${port}${contextPath}${endpoint.pattern}`;
+    const url = constructOpenUrl(contextPath, port, endpoint.pattern);
 
     const openWithExternalBrowser: boolean = vscode.workspace.getConfiguration("spring.dashboard").get("openWith") === "external";
     const browserCommand: string = openWithExternalBrowser ? "vscode.open" : "simpleBrowser.api.open";


### PR DESCRIPTION
extract `constructOpenUrl` as a utility for re-use

fix #182 