### PR TITLE
update wording of views

### DIFF
--- a/package.json
+++ b/package.json
@@ -55,24 +55,21 @@
           "name": "Apps",
           "when": "java:serverMode",
           "contextualTitle": "Spring",
-          "icon": "resources/logo.png",
-          "size": 1
+          "icon": "resources/logo.png"
         },
         {
           "id": "spring.beans",
           "name": "Beans",
           "when": "java:serverMode",
           "contextualTitle": "Spring",
-          "icon": "resources/logo.png",
-          "size": 2
+          "icon": "resources/logo.png"
         },
         {
           "id": "spring.mappings",
           "name": "Endpoint Mappings",
           "when": "java:serverMode",
           "contextualTitle": "Spring",
-          "icon": "resources/logo.png",
-          "size": 2
+          "icon": "resources/logo.png"
         }
       ]
     },

--- a/package.json
+++ b/package.json
@@ -21,7 +21,9 @@
   ],
   "activationEvents": [
     "onCommand:spring-boot-dashboard.refresh",
-    "onView:spring-boot-dashboard"
+    "onView:spring.apps",
+    "onView:spring.beans",
+    "onView:spring.mappings"
   ],
   "capabilities": {
     "virtualWorkspaces": false
@@ -42,32 +44,35 @@
         {
           "id": "spring",
           "icon": "resources/logo.png",
-          "title": "Spring"
+          "title": "Spring Boot Dashboard"
         }
       ]
     },
     "views": {
       "spring": [
         {
-          "id": "spring-boot-dashboard",
-          "name": "Spring Boot Dashboard",
+          "id": "spring.apps",
+          "name": "Apps",
           "when": "java:serverMode",
           "contextualTitle": "Spring",
-          "icon": "resources/logo.png"
+          "icon": "resources/logo.png",
+          "size": 1
         },
         {
           "id": "spring.beans",
           "name": "Beans",
           "when": "java:serverMode",
           "contextualTitle": "Spring",
-          "icon": "resources/logo.png"
+          "icon": "resources/logo.png",
+          "size": 2
         },
         {
           "id": "spring.mappings",
           "name": "Endpoint Mappings",
           "when": "java:serverMode",
           "contextualTitle": "Spring",
-          "icon": "resources/logo.png"
+          "icon": "resources/logo.png",
+          "size": 2
         }
       ]
     },

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -28,7 +28,7 @@ export async function activate(context: vscode.ExtensionContext) {
 export async function initializeExtension(_oprationId: string, context: vscode.ExtensionContext) {
     const controller: Controller = new Controller(appsProvider.manager, context);
 
-    context.subscriptions.push(vscode.window.registerTreeDataProvider('spring-boot-dashboard', appsProvider));
+    context.subscriptions.push(vscode.window.registerTreeDataProvider("spring.apps", appsProvider));
     context.subscriptions.push(instrumentOperationAsVsCodeCommand("spring-boot-dashboard.refresh", () => {
         appsProvider.manager.fireDidChangeApps(undefined);
     }));

--- a/test/suite/extension.test.ts
+++ b/test/suite/extension.test.ts
@@ -17,7 +17,7 @@ suite("Extension Test Suite", () => {
     });
 
     test("Can view static beans and mappings", async () => {
-        await vscode.commands.executeCommand("spring-boot-dashboard.focus");
+        await vscode.commands.executeCommand("spring.apps.focus");
         // workaround for https://github.com/microsoft/vscode-spring-boot-dashboard/issues/195
         await initSymbols(5000);
         let rootBean = await beansProvider.getChildren();


### PR DESCRIPTION
Now we have more views than before, so:
- change view container from "Spring" to "Spring Boot Dashboard"
- change view of apps from "Spring Boot Dashboard" to "Apps".