### PR TITLE
improve perf of fetching static beans/mappings

### DIFF
--- a/src/models/symbols.ts
+++ b/src/models/symbols.ts
@@ -9,18 +9,21 @@ import { StaticBean, StaticEndpoint } from "./StaticSymbolTypes";
 let beans: any[];
 let mappings: any[];
 
+const MAX_TIMEOUT = 20 * 60 * 1000; // 20 min
+
 export async function init(timeout?: number) {
-    const INTERVAL = 500; //ms
-    const TIMEOUT = timeout ?? 0;
+    const INTERVAL = 1000; // 1000 ms
+    const TIMEOUT = timeout ?? MAX_TIMEOUT;
     let retry = 0;
     do {
-        if (retry !== 0) {
-            await sleep(INTERVAL);
-            retry++;
-        }
         const symbols = await requestWorkspaceSymbols();
         beans = symbols.beans;
         mappings = symbols.mappings;
+
+        if (retry !== 0) {
+            await sleep(INTERVAL);
+        }
+        retry++;
     } while (!beans?.length && !mappings?.length && retry * INTERVAL < TIMEOUT);
 }
 

--- a/src/views/beans.ts
+++ b/src/views/beans.ts
@@ -3,7 +3,6 @@
 
 import * as vscode from "vscode";
 import { BootApp } from "../BootApp";
-import { initSymbols } from "../controllers/SymbolsController";
 import { LiveProcess } from "../models/liveProcess";
 import { StaticBean } from "../models/StaticSymbolTypes";
 import { getBeanDetail, getUrlOfBeanType } from "../models/stsApi";
@@ -142,7 +141,6 @@ class BeansDataProvider implements vscode.TreeDataProvider<TreeData> {
             return ret;
         }
 
-        await initSymbols();
         // all beans
         if (element instanceof LiveProcess) {
             const liveBeans =  this.store.get(element);

--- a/src/views/mappings.ts
+++ b/src/views/mappings.ts
@@ -4,7 +4,6 @@
 
 import * as vscode from "vscode";
 import { BootApp } from "../BootApp";
-import { initSymbols } from "../controllers/SymbolsController";
 import { LiveProcess } from "../models/liveProcess";
 import { StaticEndpoint } from "../models/StaticSymbolTypes";
 import { getContextPath, getPort } from "../models/stsApi";
@@ -109,7 +108,6 @@ class MappingsDataProvider implements vscode.TreeDataProvider<TreeData> {
             return ret;
         }
 
-        await initSymbols();
         // all mappings
         if (element instanceof LiveProcess) {
             const liveMappings = this.store.get(element);


### PR DESCRIPTION
BUG. Below code was never reached. Potentially consuming huge resources.
```
if (retry !== 0) {
            await sleep(INTERVAL);
            retry++;
        }
```