### PR TITLE
force to refresh static beans/mappings on rendering

### DIFF
--- a/src/models/symbols.ts
+++ b/src/models/symbols.ts
@@ -24,7 +24,7 @@ export async function init(timeout?: number) {
             await sleep(INTERVAL);
         }
         retry++;
-    } while (!beans?.length && retry * INTERVAL < TIMEOUT);
+    } while (!beans?.length && !mappings?.length && retry * INTERVAL < TIMEOUT);
 }
 
 export function getBeans(projectPath?: string) {

--- a/src/models/symbols.ts
+++ b/src/models/symbols.ts
@@ -24,7 +24,7 @@ export async function init(timeout?: number) {
             await sleep(INTERVAL);
         }
         retry++;
-    } while (!beans?.length && !mappings?.length && retry * INTERVAL < TIMEOUT);
+    } while (!beans?.length && retry * INTERVAL < TIMEOUT);
 }
 
 export function getBeans(projectPath?: string) {

--- a/src/views/beans.ts
+++ b/src/views/beans.ts
@@ -3,6 +3,7 @@
 
 import * as vscode from "vscode";
 import { BootApp } from "../BootApp";
+import { initSymbols } from "../controllers/SymbolsController";
 import { LiveProcess } from "../models/liveProcess";
 import { StaticBean } from "../models/StaticSymbolTypes";
 import { getBeanDetail, getUrlOfBeanType } from "../models/stsApi";
@@ -133,6 +134,9 @@ class BeansDataProvider implements vscode.TreeDataProvider<TreeData> {
             ret.push(...liveProcesses);
             // update context key
             vscode.commands.executeCommand("setContext", "spring.beans:hasLiveProcess", liveProcesses.length > 0);
+
+            // Workaround to force update symbols info in case STS previous returns broken data.
+            await initSymbols(5000);
 
             const staticApps = Array.from(this.staticData.keys());
             const appsWithoutLiveProcess = staticApps.filter(app => !liveProcesses.find(lp => lp.appName === app.name));

--- a/src/views/mappings.ts
+++ b/src/views/mappings.ts
@@ -4,6 +4,7 @@
 
 import * as vscode from "vscode";
 import { BootApp } from "../BootApp";
+import { initSymbols } from "../controllers/SymbolsController";
 import { LiveProcess } from "../models/liveProcess";
 import { StaticEndpoint } from "../models/StaticSymbolTypes";
 import { getContextPath, getPort } from "../models/stsApi";
@@ -100,6 +101,9 @@ class MappingsDataProvider implements vscode.TreeDataProvider<TreeData> {
             ret.push(...liveProcesses);
             // update context key
             vscode.commands.executeCommand("setContext", "spring.mappings:hasLiveProcess", liveProcesses.length > 0);
+
+            // Workaround to force update symbols info in case STS previous returns broken data.
+            await initSymbols(5000);
 
             const staticApps = Array.from(this.staticData.keys());
             const appsWithoutLiveProcess = staticApps.filter(app => !liveProcesses.find(lp => lp.appName === app.name));


### PR DESCRIPTION
It was removed by https://github.com/microsoft/vscode-spring-boot-dashboard/pull/210/files#diff-744730722b68eefedd0b0d7f98a447ec3bf593fe767954fee447741564b29bfaL145

adding back won't impact perf a lot, because now only called on rendering root nodes instead of all