### PR TITLE
stop dedup symbols

### DIFF
--- a/src/models/stsApi.ts
+++ b/src/models/stsApi.ts
@@ -3,7 +3,6 @@
 
 import * as cp from "child_process";
 import * as os from "os";
-import * as _ from "lodash";
 import * as path from 'path';
 import { promisify } from "util";
 import * as vscode from 'vscode';
@@ -128,10 +127,9 @@ export async function requestWorkspaceSymbols(_projectPath?: string): Promise<{
 }> {
     const beans = await stsApi.client.sendRequest("workspace/symbol", {"query": "@+"}) as any[];
     const mappings = await stsApi.client.sendRequest("workspace/symbol", {"query": "@/"}) as any[];
-    // Dedup symbols in case of duplicated items in response
-    // Workaround for https://github.com/spring-projects/sts4/issues/820
+
     return {
-        beans: _.uniqBy(beans, 'name'),
-        mappings: _.uniqBy(mappings, 'name')
+        beans,
+        mappings
     };
 }


### PR DESCRIPTION
The workaround causes #228 in some cases.

Simply remove the workaround as https://github.com/spring-projects/sts4/issues/820 has been fixed.
