### PR TITLE
support to fetch symbols for specific project only

### DIFF
--- a/src/gutter/index.ts
+++ b/src/gutter/index.ts
@@ -15,8 +15,8 @@ function decorateEditor(textEditor: vscode.TextEditor) {
         return;
     }
 
-    const beans = (getBeans() ?? []).map(b => new StaticBean(b));
-    const mappings = (getMappings() ?? []).map(m => new StaticEndpoint(m));
+    const beans = (getBeans(textEditor.document.uri) ?? []).map(b => new StaticBean(b));
+    const mappings = (getMappings(textEditor.document.uri) ?? []).map(m => new StaticEndpoint(m));
     const beansInCurrentEditor = beans.filter(b => isSameUriString(b.location.uri, textEditor.document.uri));
     const endpointsInCurrentEditor = mappings.filter(m => isSameUriString(m.location.uri, textEditor.document.uri));
     if (beansInCurrentEditor.length + endpointsInCurrentEditor.length > 0) {

--- a/src/models/symbols.ts
+++ b/src/models/symbols.ts
@@ -1,10 +1,11 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license.
 
-import { requestWorkspaceSymbols } from "./stsApi";
 import * as vscode from "vscode";
+import { sanitizeFilePath } from "../symbolUtils";
 import { sleep } from "../utils";
 import { StaticBean, StaticEndpoint } from "./StaticSymbolTypes";
+import { requestWorkspaceSymbols } from "./stsApi";
 
 let beans: any[];
 let mappings: any[];
@@ -27,26 +28,22 @@ export async function init(timeout?: number) {
     } while (!beans?.length && !mappings?.length && retry * INTERVAL < TIMEOUT);
 }
 
-export function getBeans(projectPath?: string) {
+export function getBeans(projectPath?: string | vscode.Uri) {
     if (!projectPath) {
         return beans;
     }
 
     const path = sanitizeFilePath(projectPath);
-    return beans.filter(b => sanitizeFilePath(b.location.uri).startsWith(path));
+    return beans?.filter(b => sanitizeFilePath(b.location.uri).startsWith(path));
 }
 
-export function getMappings(projectPath?: string) {
+export function getMappings(projectPath?: string | vscode.Uri) {
     if (!projectPath) {
         return mappings;
     }
 
     const path = sanitizeFilePath(projectPath);
-    return mappings.filter(b => sanitizeFilePath(b.location.uri).startsWith(path));
-}
-
-function sanitizeFilePath(uri: string) {
-    return uri.replace(/^file:\/+/, "");
+    return mappings?.filter(b => sanitizeFilePath(b.location.uri).startsWith(path));
 }
 
 export async function navigateToLocation(symbol: StaticEndpoint | StaticBean | {corresponding: StaticEndpoint}) {

--- a/src/symbolUtils.ts
+++ b/src/symbolUtils.ts
@@ -11,3 +11,10 @@ function rangeEquals(ra: vscode.Range, rb: vscode.Range): boolean {
 function positionEquals(pa: vscode.Position, pb: vscode.Position): boolean {
     return pa.line === pb.line && pa.character === pb.character;
 }
+
+export function sanitizeFilePath(uriLike: string | vscode.Uri) {
+    if (uriLike instanceof vscode.Uri) {
+        return uriLike.path;
+    }
+    return vscode.Uri.parse(uriLike).path;
+}


### PR DESCRIPTION
> pass in a search query like locationPrefix:file:///Users/<username>/workspace/workspaces/path-to-project/? , which is basically `locationPrefix:` followed by the URI that is being used to filter the symbols, followed by a `?` to separate further search query input. 

Previously we always ask for all symbols and filter on the client side. It's supported to filter symbols in STS LS directly. This would improve performance somehow.