### PR TITLE
show spring view container for empty workspace

### DIFF
--- a/package.json
+++ b/package.json
@@ -54,21 +54,21 @@
         {
           "id": "spring.apps",
           "name": "Apps",
-          "when": "java:serverMode",
+          "when": "java:serverMode || workbenchState==empty",
           "contextualTitle": "Spring",
           "icon": "resources/logo.png"
         },
         {
           "id": "spring.beans",
           "name": "Beans",
-          "when": "java:serverMode",
+          "when": "java:serverMode || workbenchState==empty",
           "contextualTitle": "Spring",
           "icon": "resources/logo.png"
         },
         {
           "id": "spring.mappings",
           "name": "Endpoint Mappings",
-          "when": "java:serverMode",
+          "when": "java:serverMode || workbenchState==empty",
           "contextualTitle": "Spring",
           "icon": "resources/logo.png"
         },


### PR DESCRIPTION
When the workspace is empty, without showing any view inside the view container, the spring icon won't show in activity bar.
In getting started walkthough of spring extension pack, usually it's an empty workspace, "Reveal in Dashboard" is broken.
