### PR TITLE
fix error in styling sheet

### DIFF
--- a/resources/webview-ui/styles.css
+++ b/resources/webview-ui/styles.css
@@ -8,24 +8,7 @@ h1 {
   justify-content: center;
 }
 
-/* There's no delement with id "results-container", what was it for */
-/* #results-container {
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  background-color: var(--vscode-input-background);
-  padding: 1rem;
-  margin: 1rem 0;
-} */
-
 .chart-container {
   width: 100%;
   height: 100%;
 }
-
-/* There's no delement with id "icon", can we remove it? */
-/* #icon {
-  font-size: 3em;
-  padding: 0;
-  margin: 0;
-} */

--- a/resources/webview-ui/styles.css
+++ b/resources/webview-ui/styles.css
@@ -2,28 +2,30 @@ h1 {
   font-size: 1.5em;
 }
 
-#search-container {
+.search-container {
   display: flex;
   flex-direction: column;
   justify-content: center;
 }
 
-#results-container {
+/* There's no delement with id "results-container", what was it for */
+/* #results-container {
   display: flex;
   align-items: center;
   justify-content: space-between;
   background-color: var(--vscode-input-background);
   padding: 1rem;
   margin: 1rem 0;
-}
+} */
 
-#chart-container {
+.chart-container {
   width: 100%;
   height: 100%;
 }
 
-#icon {
+/* There's no delement with id "icon", can we remove it? */
+/* #icon {
   font-size: 3em;
   padding: 0;
   margin: 0;
-}
+} */

--- a/src/views/memory.ts
+++ b/src/views/memory.ts
@@ -164,12 +164,12 @@ class MemoryProvider implements WebviewViewProvider{
               <div class="chart-container" style="position: relative;" height="350">
                 <canvas id="chart" height="350"></canvas>
               </div>
-              <section id="search-container">
+              <section class="search-container">
                 <vscode-dropdown id="process">
                 </vscode-dropdown>
               </section>
               <br>
-              <section id="search-container">
+              <section class="search-container">
                 <vscode-dropdown id="graphType">
                   <vscode-option value="memory">Heap Memory</vscode-option>
                   <vscode-option value="memory">Non Heap Memory</vscode-option>


### PR DESCRIPTION
Due to #260 , I re-visited the memory view impl, this PR fixes some obvious mistakes in styling sheet:
- we cannot have two elements with same id: `search-container`
- remove some unused stylings

But it probably still won't "fix" #260 , which I assume should be either bug of chart.js or the misuse of it.