### PR TITLE
Fix: memory view doesn't hide after live process got disconnected

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -22,6 +22,9 @@
             "rendererDebugOptions": {
                 "webRoot": "${workspaceFolder}/resources/webview-ui",
                 "urlFilter": "*vscjava.vscode-spring-boot-dashboard*"
+            },
+            "env": {
+                "DEBUG_TELEMETRY": "true"
             }
         },
         {

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -10,6 +10,7 @@
             "type": "extensionHost",
             "request": "launch",
             "runtimeExecutable": "${execPath}",
+            "debugWebviews": true,
             "args": [
                 "${workspaceFolder}/test/projects/spring-petclinic",
                 "--extensionDevelopmentPath=${workspaceFolder}"
@@ -17,7 +18,11 @@
             "outFiles": [
                 "${workspaceFolder}/out/**/*.js"
             ],
-            "preLaunchTask": "npm: watch"
+            "preLaunchTask": "npm: watch",
+            "rendererDebugOptions": {
+                "webRoot": "${workspaceFolder}/resources/webview-ui",
+                "urlFilter": "*vscjava.vscode-spring-boot-dashboard*"
+            }
         },
         {
             "name": "Extension<gs-rest-service>",

--- a/resources/webview-ui/main.js
+++ b/resources/webview-ui/main.js
@@ -12,7 +12,7 @@ function main() {
   const processSelection = document.getElementById("process");
   processSelection.addEventListener("change", changeGraphDisplay);
 
-  if(processSelection.options.length === 0) {
+  if (processSelection.options.length === 0) {
     vscode.postMessage({
       command: "LoadProcess",
       text: "Load process list",
@@ -42,7 +42,7 @@ function loadInitialGraph() {
 
 function loadMetrics() {
   const processKey = document.getElementById("process").value;
-  if(processKey !== '' || processKey !== undefined) {
+  if (processKey !== '' || processKey !== undefined) {
     vscode.postMessage({
       command: "LoadMetrics",
       text: "Load metrics for the graph",
@@ -55,7 +55,7 @@ function fetchGraphData() {
   const selection = document.getElementById("graphType");
   const graphType = selection.options[selection.selectedIndex].text;
   const processKey = document.getElementById("process").value;
-  if(selection !== "" && processKey !== "") {
+  if (selection !== "" && processKey !== "") {
     vscode.postMessage({
       command: "FetchData",
       text: "Fetch data to plot the graph",
@@ -69,7 +69,7 @@ function changeGraphDisplay() {
   let chartStatus = Chart.getChart("chart");
   fetchGraphData();
   if (chartStatus !== undefined) {
-      chartStatus.destroy();
+    chartStatus.destroy();
   }
 }
 
@@ -109,25 +109,25 @@ function setVSCodeMessageListener() {
 }
 
 function displayProcess(process) {
-  if(process !== '' && process !== undefined && Array.isArray(process)) {
+  if (process !== '' && process !== undefined && Array.isArray(process)) {
     const processList = document.getElementById("process");
     for (let proc of process) {
       var processKey = window.btoa(proc.processKey);
-      processList.insertAdjacentHTML("beforeend",`<vscode-option id="${processKey}" value="${processKey}">${proc.appName} (pid: ${proc.pid})</vscode-option>`);
+      processList.insertAdjacentHTML("beforeend", `<vscode-option id="${processKey}" value="${processKey}">${proc.appName} (pid: ${proc.pid})</vscode-option>`);
     }
   }
 }
 
 function removeProcess(processKey) {
-  if(processKey !== '' || processKey !== undefined) {
+  if (processKey !== '' || processKey !== undefined) {
     var key = window.btoa(processKey);
     const option = document.getElementById(key);
     option.remove(option.index);
     const currentSelection = document.getElementById("process").value;
     let chartStatus = Chart.getChart("chart");
     if (chartStatus !== undefined && currentSelection === key) {
-        chartStatus.destroy();
-        loadInitialGraph();
+      chartStatus.destroy();
+      loadInitialGraph();
     }
   }
 }
@@ -137,7 +137,7 @@ function getMemoryData(data, memoryZones) {
     time: data[0].time
   };
   (memoryZones).forEach((zone, i) => {
-      dataPoint[zone] = data[++i].measurements?.[0].value / 1_000_000;
+    dataPoint[zone] = data[++i].measurements?.[0].value / 1_000_000;
   });
   dataPoint["committed"] = data[data.length - 2].measurements?.[0].value / 1_000_000;
   dataPoint["max"] = data[data.length - 1].measurements?.[0].value / 1_000_000;
@@ -151,7 +151,7 @@ function displayGraphData(graphData) {
     case "Heap Memory":
       var memoryZones = graphData[0][0].availableTags?.[0].values;
       var dataPoints = graphData.map(data => getMemoryData(data, memoryZones));
-      plotMemoryGraph(dataPoints, memoryZones, graphType );
+      plotMemoryGraph(dataPoints, memoryZones, graphType);
       break;
     case "Non Heap Memory":
       var memoryZones = graphData[0][0].availableTags?.[0].values;
@@ -159,13 +159,13 @@ function displayGraphData(graphData) {
       plotMemoryGraph(dataPoints, memoryZones, graphType);
       break;
     case "Gc Pauses":
-      var extraData = {label: 'Max', prop: 'MAX', unit: 'ms'};
+      var extraData = { label: 'Max', prop: 'MAX', unit: 'ms' };
       var unit = "ms/s";
       var label = "Duration"
       plotGcGraph(graphData, "Gc Pauses", extraData, unit, label);
       break;
     case "Garbage Collections":
-      var extraData = {label: 'Count', prop: 'TOTAL_TIME'};
+      var extraData = { label: 'Count', prop: 'TOTAL_TIME' };
       var label = "Count / second"
       plotGcGraph(graphData, "Garbage Collections", extraData, "", label);
       break;
@@ -176,28 +176,28 @@ function displayGraphData(graphData) {
 
 function currentUsedMemory(zones, graphData) {
   return zones
-      .map((z) => graphData[z])
-      .reduce((v, a) => a + v, 0);
+    .map((z) => graphData[z])
+    .reduce((v, a) => a + v, 0);
 }
 
 function showMetrics(zones, graphData) {
-  return `Size `+ Math.round(graphData[0]["committed"]) + ` MB`
-   +` / `+ `Used `+ Math.round(currentUsedMemory(zones, graphData[0])) + ` MB`
-   +` / `+ `Max `+ Math.round(graphData[0]["max"])+ ` MB`;
+  return `Size ` + Math.round(graphData[0]["committed"]) + ` MB`
+    + ` / ` + `Used ` + Math.round(currentUsedMemory(zones, graphData[0])) + ` MB`
+    + ` / ` + `Max ` + Math.round(graphData[0]["max"]) + ` MB`;
 }
 
 function setMemoryData(chart, dataPoints, zones) {
   const labels = chart.labels;
   var sets = chart.datasets.length;
-    dataPoints.map((d) => {
-      if(!labels.includes(d.time)) {
-        labels.push(d.time);
-        zones.forEach((zone, i) => {
-          chart.datasets[i].data.push(d[zone]);
-        });
-        chart.datasets[sets -1].data.push(d["committed"]);
-      }
-    })
+  dataPoints.map((d) => {
+    if (!labels.includes(d.time)) {
+      labels.push(d.time);
+      zones.forEach((zone, i) => {
+        chart.datasets[i].data.push(d[zone]);
+      });
+      chart.datasets[sets - 1].data.push(d["committed"]);
+    }
+  })
 }
 
 function getLabels(data) {
@@ -261,42 +261,42 @@ function plotMemoryGraph(graphData, zones, graphType) {
           labelOffset: -5,
         }
       }
-   },
+    },
     plugins: {
       title: {
         display: true,
         position: "top",
         text: [graphType, showMetrics(zones, graphData)]
       },
-    tooltip: {
-      mode: 'index',
-      itemSort: function(a, b) {
-        return b.datasetIndex - a.datasetIndex
+      tooltip: {
+        mode: 'index',
+        itemSort: function (a, b) {
+          return b.datasetIndex - a.datasetIndex
+        },
       },
-    },
-    interaction: {
-      mode: 'nearest',
-      axis: 'x',
-      intersect: false,
-    },
-    legend: {
-      display: true,
-      position: "bottom",
-      labels: {
-        boxHeight: 0,
-        boxWidth: 15
+      interaction: {
+        mode: 'nearest',
+        axis: 'x',
+        intersect: false,
+      },
+      legend: {
+        display: true,
+        position: "bottom",
+        labels: {
+          boxHeight: 0,
+          boxWidth: 15
+        }
       }
-    }
-  },
+    },
   };
   let chartStatus = Chart.getChart("chart");
   if (chartStatus === undefined) {
-      var memChart = new Chart(ctx, {
-        type: 'line',
-        data: data,
-        options: options
-      });
-      memChart.data.labels.shift();
+    var memChart = new Chart(ctx, {
+      type: 'line',
+      data: data,
+      options: options
+    });
+    memChart.data.labels.shift();
   }
   var chart = Chart.getChart("chart");
 
@@ -304,7 +304,7 @@ function plotMemoryGraph(graphData, zones, graphType) {
 
   setMemoryData(chart.data, graphData, zones);
 
-  while(datapoints >= maxDataPoints) {
+  while (datapoints >= maxDataPoints) {
     chart.data.labels.shift();
     chart.data.datasets.forEach((d) => {
       d.data.shift();
@@ -317,34 +317,33 @@ function plotMemoryGraph(graphData, zones, graphType) {
 
 
 function formula(next, prev, type) {
-  if(type === "Gc Pauses")
-   {
+  if (type === "Gc Pauses") {
     return next.count < prev.count ? 1000 * (next.total - prev.total) / (next.count - prev.count) : 0;
-   }
+  }
   return next.count - prev.count;
 }
 
 function showGcMetrics(unit, extraData, data) {
-  return extraData.label +': '+ Math.round(data[0].measurements.find(x => x.statistic === extraData.prop)?.value) + unit;
+  return extraData.label + ': ' + Math.round(data[0].measurements.find(x => x.statistic === extraData.prop)?.value) + unit;
 }
 
-function setGcPausesData(chart, dataPoints , type) {
+function setGcPausesData(chart, dataPoints, type) {
   const labels = chart.labels;
 
 
   dataPoints.map((d) => {
-    if(!labels.includes(d[0].time)) {
+    if (!labels.includes(d[0].time)) {
       const prev = chart.datasets[0].prevMeasurement;
       labels.push(d[0].time);
       if (prev) {
         var dataPoint = getGcPausesData(d[0]);
         const pt = {
-            time: d[0].time,
-            gc: formula(dataPoint, prev, type)
+          time: d[0].time,
+          gc: formula(dataPoint, prev, type)
         }
         chart.datasets[0].prevMeasurement = dataPoint;
         chart.datasets[0].data.push(pt);
-     }
+      }
     }
   })
 }
@@ -392,46 +391,46 @@ function plotGcGraph(graphData, type, extraData, unit, label) {
           labelOffset: -5
         }
       }
-   },
-   plugins: {
-    title: {
-      display: true,
-      position: "top",
-      text: ['Gc Pauses', showGcMetrics(unit, extraData, graphData[0])]
     },
-   tooltip: {
-    mode: 'index'
-   },
-   interaction: {
-    mode: 'nearest',
-    axis: 'x',
-    intersect: false,
-  },
-  legend: {
-    display: true,
-    position: "bottom",
-    labels: {
-      boxHeight: 0,
-      boxWidth: 15
-    }
-  }
- },
+    plugins: {
+      title: {
+        display: true,
+        position: "top",
+        text: ['Gc Pauses', showGcMetrics(unit, extraData, graphData[0])]
+      },
+      tooltip: {
+        mode: 'index'
+      },
+      interaction: {
+        mode: 'nearest',
+        axis: 'x',
+        intersect: false,
+      },
+      legend: {
+        display: true,
+        position: "bottom",
+        labels: {
+          boxHeight: 0,
+          boxWidth: 15
+        }
+      }
+    },
   };
   let chartStatus = Chart.getChart("chart");
   if (chartStatus === undefined) {
-      var gcChart = new Chart(ctx, {
-        type: 'line',
-        data: data,
-        options: options
-      });
+    var gcChart = new Chart(ctx, {
+      type: 'line',
+      data: data,
+      options: options
+    });
 
-      var gcPause = {
-        total: graphData[0][0].measurements.find(x => x.statistic === 'TOTAL_TIME')?.value,
-        count: graphData[0][0].measurements.find(x => x.statistic === 'COUNT')?.value,
-        max: graphData[0][0].measurements.find(x => x.statistic === 'MAX')?.value
-      }
-      gcChart.data.datasets[0].prevMeasurement= gcPause
-      gcChart.data.labels.shift();
+    var gcPause = {
+      total: graphData[0][0].measurements.find(x => x.statistic === 'TOTAL_TIME')?.value,
+      count: graphData[0][0].measurements.find(x => x.statistic === 'COUNT')?.value,
+      max: graphData[0][0].measurements.find(x => x.statistic === 'MAX')?.value
+    }
+    gcChart.data.datasets[0].prevMeasurement = gcPause
+    gcChart.data.labels.shift();
   }
 
   var chart = Chart.getChart("chart");
@@ -440,7 +439,7 @@ function plotGcGraph(graphData, type, extraData, unit, label) {
 
   setGcPausesData(chart.data, graphData, type);
 
-  while(datapoints >= maxDataPoints) {
+  while (datapoints >= maxDataPoints) {
     chart.data.labels.shift();
     chart.data.datasets[0].data.shift();
     datapoints = datapoints - 1;

--- a/resources/webview-ui/main.js
+++ b/resources/webview-ui/main.js
@@ -1,11 +1,11 @@
-// Get access to the VS Code API from within the webview context
-const vscode = acquireVsCodeApi();
+(function () {
+  // Get access to the VS Code API from within the webview context
+  const vscode = acquireVsCodeApi();
 
-window.addEventListener("load", main);
-var loadMetricsTimer;
-var fetchGraphDataTimer;
-// Main function that gets executed once the webview DOM loads
-function main() {
+  let loadMetricsTimer;
+  let fetchGraphDataTimer;
+
+  // <-- start main func
   const graphTypeSelection = document.getElementById("graphType");
   graphTypeSelection.addEventListener("change", changeGraphDisplay);
 
@@ -26,426 +26,427 @@ function main() {
   fetchGraphDataTimer = setInterval(fetchGraphData, interval);
 
   setVSCodeMessageListener();
-}
+  // end main func -->
 
-function loadInitialGraph() {
-  const graphTypeSelection = document.getElementById("graphType");
-  const graphType = graphTypeSelection.options[graphTypeSelection.selectedIndex].text;
+  function loadInitialGraph() {
+    const graphTypeSelection = document.getElementById("graphType");
+    const graphType = graphTypeSelection.options[graphTypeSelection.selectedIndex].text;
 
-  vscode.postMessage({
-    command: "FetchData",
-    text: "Fetch data to plot the graph",
-    processKey: "",
-    type: graphType,
-  });
-}
-
-function loadMetrics() {
-  const processKey = document.getElementById("process").value;
-  if (processKey !== '' || processKey !== undefined) {
-    vscode.postMessage({
-      command: "LoadMetrics",
-      text: "Load metrics for the graph",
-      processKey: window.atob(processKey),
-    });
-  }
-}
-
-function fetchGraphData() {
-  const selection = document.getElementById("graphType");
-  const graphType = selection.options[selection.selectedIndex].text;
-  const processKey = document.getElementById("process").value;
-  if (selection !== "" && processKey !== "") {
     vscode.postMessage({
       command: "FetchData",
       text: "Fetch data to plot the graph",
-      processKey: window.atob(processKey),
+      processKey: "",
       type: graphType,
     });
   }
-}
 
-function changeGraphDisplay() {
-  let chartStatus = Chart.getChart("chart");
-  fetchGraphData();
-  if (chartStatus !== undefined) {
-    chartStatus.destroy();
-  }
-}
-
-function refreshMetrics() {
-  clearInterval(loadMetricsTimer);
-  clearInterval(fetchGraphDataTimer);
-  loadMetrics();
-  loadMetricsTimer = setInterval(loadMetrics, interval);
-  fetchGraphDataTimer = setInterval(fetchGraphData, interval);
-}
-
-// Sets up an event listener to listen for messages passed from the extension context
-// and executes code based on the message that is received
-function setVSCodeMessageListener() {
-  window.addEventListener("message", (event) => {
-    const command = event.data.command;
-    switch (command) {
-      case "displayGraph":
-        const graphData = JSON.parse(event.data.payload);
-        displayGraphData(graphData);
-        break;
-      case "displayProcess":
-        const process = event.data.process;
-        displayProcess(process);
-        break;
-      case "removeProcess":
-        const p = JSON.parse(event.data.process);
-        removeProcess(p.liveProcess.processKey);
-        break;
-      case "updateSettings":
-        interval = event.data.interval;
-        maxDataPoints = event.data.maxDataPoints;
-        refreshMetrics();
-        break;
-    }
-  });
-}
-
-function displayProcess(process) {
-  if (process !== '' && process !== undefined && Array.isArray(process)) {
-    const processList = document.getElementById("process");
-    for (let proc of process) {
-      var processKey = window.btoa(proc.processKey);
-      processList.insertAdjacentHTML("beforeend", `<vscode-option id="${processKey}" value="${processKey}">${proc.appName} (pid: ${proc.pid})</vscode-option>`);
-    }
-  }
-}
-
-function removeProcess(processKey) {
-  if (processKey !== '' || processKey !== undefined) {
-    var key = window.btoa(processKey);
-    const option = document.getElementById(key);
-    option.remove(option.index);
-    const currentSelection = document.getElementById("process").value;
-    let chartStatus = Chart.getChart("chart");
-    if (chartStatus !== undefined && currentSelection === key) {
-      chartStatus.destroy();
-      loadInitialGraph();
-    }
-  }
-}
-
-function getMemoryData(data, memoryZones) {
-  const dataPoint = {
-    time: data[0].time
-  };
-  (memoryZones).forEach((zone, i) => {
-    dataPoint[zone] = data[++i].measurements?.[0].value / 1_000_000;
-  });
-  dataPoint["committed"] = data[data.length - 2].measurements?.[0].value / 1_000_000;
-  dataPoint["max"] = data[data.length - 1].measurements?.[0].value / 1_000_000;
-  return dataPoint;
-}
-
-function displayGraphData(graphData) {
-  const selection = document.getElementById("graphType");
-  const graphType = selection.options[selection.selectedIndex].text;
-  switch (graphType) {
-    case "Heap Memory":
-      var memoryZones = graphData[0][0].availableTags?.[0].values;
-      var dataPoints = graphData.map(data => getMemoryData(data, memoryZones));
-      plotMemoryGraph(dataPoints, memoryZones, graphType);
-      break;
-    case "Non Heap Memory":
-      var memoryZones = graphData[0][0].availableTags?.[0].values;
-      var dataPoints = graphData.map(data => getMemoryData(data, memoryZones));
-      plotMemoryGraph(dataPoints, memoryZones, graphType);
-      break;
-    case "Gc Pauses":
-      var extraData = { label: 'Max', prop: 'MAX', unit: 'ms' };
-      var unit = "ms/s";
-      var label = "Duration"
-      plotGcGraph(graphData, "Gc Pauses", extraData, unit, label);
-      break;
-    case "Garbage Collections":
-      var extraData = { label: 'Count', prop: 'TOTAL_TIME' };
-      var label = "Count / second"
-      plotGcGraph(graphData, "Garbage Collections", extraData, "", label);
-      break;
-    default:
-  }
-
-}
-
-function currentUsedMemory(zones, graphData) {
-  return zones
-    .map((z) => graphData[z])
-    .reduce((v, a) => a + v, 0);
-}
-
-function showMetrics(zones, graphData) {
-  return `Size ` + Math.round(graphData[0]["committed"]) + ` MB`
-    + ` / ` + `Used ` + Math.round(currentUsedMemory(zones, graphData[0])) + ` MB`
-    + ` / ` + `Max ` + Math.round(graphData[0]["max"]) + ` MB`;
-}
-
-function setMemoryData(chart, dataPoints, zones) {
-  const labels = chart.labels;
-  var sets = chart.datasets.length;
-  dataPoints.map((d) => {
-    if (!labels.includes(d.time)) {
-      labels.push(d.time);
-      zones.forEach((zone, i) => {
-        chart.datasets[i].data.push(d[zone]);
+  function loadMetrics() {
+    const processKey = document.getElementById("process").value;
+    if (processKey !== '' || processKey !== undefined) {
+      vscode.postMessage({
+        command: "LoadMetrics",
+        text: "Load metrics for the graph",
+        processKey: window.atob(processKey),
       });
-      chart.datasets[sets - 1].data.push(d["committed"]);
     }
-  })
-}
+  }
 
-function getLabels(data) {
-  var res = data.map(m => m.time);
-  return res;
-}
+  function fetchGraphData() {
+    const selection = document.getElementById("graphType");
+    const graphType = selection.options[selection.selectedIndex].text;
+    const processKey = document.getElementById("process").value;
+    if (selection !== "" && processKey !== "") {
+      vscode.postMessage({
+        command: "FetchData",
+        text: "Fetch data to plot the graph",
+        processKey: window.atob(processKey),
+        type: graphType,
+      });
+    }
+  }
 
-function plotMemoryGraph(graphData, zones, graphType) {
-  const COLORS = [
-    ["#c4e8c1", "#5eb84d"],
-    ["#f5c162", "#ffa500"],
-    ["#9987ad", "#75539e"],
-    ["#d4b0d4", "#e362e3"],
-    ["#92bed2", "#3282bf"],
-    ["#f5d28c", "#f0debb"]
-  ];
+  function changeGraphDisplay() {
+    let chartStatus = Chart.getChart("chart");
+    fetchGraphData();
+    if (chartStatus !== undefined) {
+      chartStatus.destroy();
+    }
+  }
 
-  var ctx = document.getElementById("chart").getContext("2d");
-  var dataset = [];
-  zones.forEach((zone, i) => {
+  function refreshMetrics() {
+    clearInterval(loadMetricsTimer);
+    clearInterval(fetchGraphDataTimer);
+    loadMetrics();
+    loadMetricsTimer = setInterval(loadMetrics, interval);
+    fetchGraphDataTimer = setInterval(fetchGraphData, interval);
+  }
+
+  // Sets up an event listener to listen for messages passed from the extension context
+  // and executes code based on the message that is received
+  function setVSCodeMessageListener() {
+    window.addEventListener("message", (event) => {
+      const command = event.data.command;
+      switch (command) {
+        case "displayGraph":
+          const graphData = JSON.parse(event.data.payload);
+          displayGraphData(graphData);
+          break;
+        case "displayProcess":
+          const process = event.data.process;
+          displayProcess(process);
+          break;
+        case "removeProcess":
+          const p = JSON.parse(event.data.process);
+          removeProcess(p.liveProcess.processKey);
+          break;
+        case "updateSettings":
+          interval = event.data.interval;
+          maxDataPoints = event.data.maxDataPoints;
+          refreshMetrics();
+          break;
+      }
+    });
+  }
+
+  function displayProcess(process) {
+    if (process !== '' && process !== undefined && Array.isArray(process)) {
+      const processList = document.getElementById("process");
+      for (let proc of process) {
+        var processKey = window.btoa(proc.processKey);
+        processList.insertAdjacentHTML("beforeend", `<vscode-option id="${processKey}" value="${processKey}">${proc.appName} (pid: ${proc.pid})</vscode-option>`);
+      }
+    }
+  }
+
+  function removeProcess(processKey) {
+    if (processKey !== '' || processKey !== undefined) {
+      var key = window.btoa(processKey);
+      const option = document.getElementById(key);
+      option.remove(option.index);
+      const currentSelection = document.getElementById("process").value;
+      let chartStatus = Chart.getChart("chart");
+      if (chartStatus !== undefined && currentSelection === key) {
+        chartStatus.destroy();
+        loadInitialGraph();
+      }
+    }
+  }
+
+  function getMemoryData(data, memoryZones) {
+    const dataPoint = {
+      time: data[0].time
+    };
+    (memoryZones).forEach((zone, i) => {
+      dataPoint[zone] = data[++i].measurements?.[0].value / 1_000_000;
+    });
+    dataPoint["committed"] = data[data.length - 2].measurements?.[0].value / 1_000_000;
+    dataPoint["max"] = data[data.length - 1].measurements?.[0].value / 1_000_000;
+    return dataPoint;
+  }
+
+  function displayGraphData(graphData) {
+    const selection = document.getElementById("graphType");
+    const graphType = selection.options[selection.selectedIndex].text;
+    switch (graphType) {
+      case "Heap Memory":
+        var memoryZones = graphData[0][0].availableTags?.[0].values;
+        var dataPoints = graphData.map(data => getMemoryData(data, memoryZones));
+        plotMemoryGraph(dataPoints, memoryZones, graphType);
+        break;
+      case "Non Heap Memory":
+        var memoryZones = graphData[0][0].availableTags?.[0].values;
+        var dataPoints = graphData.map(data => getMemoryData(data, memoryZones));
+        plotMemoryGraph(dataPoints, memoryZones, graphType);
+        break;
+      case "Gc Pauses":
+        var extraData = { label: 'Max', prop: 'MAX', unit: 'ms' };
+        var unit = "ms/s";
+        var label = "Duration"
+        plotGcGraph(graphData, "Gc Pauses", extraData, unit, label);
+        break;
+      case "Garbage Collections":
+        var extraData = { label: 'Count', prop: 'TOTAL_TIME' };
+        var label = "Count / second"
+        plotGcGraph(graphData, "Garbage Collections", extraData, "", label);
+        break;
+      default:
+    }
+
+  }
+
+  function currentUsedMemory(zones, graphData) {
+    return zones
+      .map((z) => graphData[z])
+      .reduce((v, a) => a + v, 0);
+  }
+
+  function showMetrics(zones, graphData) {
+    return `Size ` + Math.round(graphData[0]["committed"]) + ` MB`
+      + ` / ` + `Used ` + Math.round(currentUsedMemory(zones, graphData[0])) + ` MB`
+      + ` / ` + `Max ` + Math.round(graphData[0]["max"]) + ` MB`;
+  }
+
+  function setMemoryData(chart, dataPoints, zones) {
+    const labels = chart.labels;
+    var sets = chart.datasets.length;
+    dataPoints.map((d) => {
+      if (!labels.includes(d.time)) {
+        labels.push(d.time);
+        zones.forEach((zone, i) => {
+          chart.datasets[i].data.push(d[zone]);
+        });
+        chart.datasets[sets - 1].data.push(d["committed"]);
+      }
+    })
+  }
+
+  function getLabels(data) {
+    var res = data.map(m => m.time);
+    return res;
+  }
+
+  function plotMemoryGraph(graphData, zones, graphType) {
+    const COLORS = [
+      ["#c4e8c1", "#5eb84d"],
+      ["#f5c162", "#ffa500"],
+      ["#9987ad", "#75539e"],
+      ["#d4b0d4", "#e362e3"],
+      ["#92bed2", "#3282bf"],
+      ["#f5d28c", "#f0debb"]
+    ];
+
+    var ctx = document.getElementById("chart").getContext("2d");
+    var dataset = [];
+    zones.forEach((zone, i) => {
+      dataset.push({
+        label: zone,
+        stacked: true,
+        stack: "stack 0",
+        backgroundColor: COLORS[i][0],
+        borderColor: COLORS[i][1],
+        fillColor: COLORS[i][0],
+        fill: true,
+        data: []
+      })
+    });
+
+    // committed dataset
     dataset.push({
-      label: zone,
-      stacked: true,
-      stack: "stack 0",
-      backgroundColor: COLORS[i][0],
-      borderColor: COLORS[i][1],
-      fillColor: COLORS[i][0],
+      label: "Committed",
+      stacked: false,
+      backgroundColor: "#c9cbcf",
+      borderColor: "#a0a1a3",
+      fillColor: "#c9cbcf",
       fill: true,
       data: []
     })
-  });
 
-  // committed dataset
-  dataset.push({
-    label: "Committed",
-    stacked: false,
-    backgroundColor: "#c9cbcf",
-    borderColor: "#a0a1a3",
-    fillColor: "#c9cbcf",
-    fill: true,
-    data: []
-  })
-
-  var data = {
-    labels: [],
-    datasets: dataset
-  };
-  var options = {
-    animation: false,
-    maintainAspectRatio: false,
-    scales: {
-      x: {},
-      y: {
-        suggestedMin: 0,
-        suggestedMax: graphData["committed"],
-        stacked: true,
+    var data = {
+      labels: [],
+      datasets: dataset
+    };
+    var options = {
+      animation: false,
+      maintainAspectRatio: false,
+      scales: {
+        x: {},
+        y: {
+          suggestedMin: 0,
+          suggestedMax: graphData["committed"],
+          stacked: true,
+          title: {
+            display: true,
+            text: 'MB',
+            padding: -2,
+            labelOffset: -5,
+          }
+        }
+      },
+      plugins: {
         title: {
           display: true,
-          text: 'MB',
-          padding: -2,
-          labelOffset: -5,
-        }
-      }
-    },
-    plugins: {
-      title: {
-        display: true,
-        position: "top",
-        text: [graphType, showMetrics(zones, graphData)]
-      },
-      tooltip: {
-        mode: 'index',
-        itemSort: function (a, b) {
-          return b.datasetIndex - a.datasetIndex
+          position: "top",
+          text: [graphType, showMetrics(zones, graphData)]
         },
-      },
-      interaction: {
-        mode: 'nearest',
-        axis: 'x',
-        intersect: false,
-      },
-      legend: {
-        display: true,
-        position: "bottom",
-        labels: {
-          boxHeight: 0,
-          boxWidth: 15
+        tooltip: {
+          mode: 'index',
+          itemSort: function (a, b) {
+            return b.datasetIndex - a.datasetIndex
+          },
+        },
+        interaction: {
+          mode: 'nearest',
+          axis: 'x',
+          intersect: false,
+        },
+        legend: {
+          display: true,
+          position: "bottom",
+          labels: {
+            boxHeight: 0,
+            boxWidth: 15
+          }
         }
-      }
-    },
-  };
-  let chartStatus = Chart.getChart("chart");
-  if (chartStatus === undefined) {
-    var memChart = new Chart(ctx, {
-      type: 'line',
-      data: data,
-      options: options
-    });
-    memChart.data.labels.shift();
-  }
-  var chart = Chart.getChart("chart");
-
-  var datapoints = chart.data.datasets[0].data.length;
-
-  setMemoryData(chart.data, graphData, zones);
-
-  while (datapoints >= maxDataPoints) {
-    chart.data.labels.shift();
-    chart.data.datasets.forEach((d) => {
-      d.data.shift();
-    });
-    datapoints = datapoints - 1;
-  }
-
-  chart.update();
-}
-
-
-function formula(next, prev, type) {
-  if (type === "Gc Pauses") {
-    return next.count < prev.count ? 1000 * (next.total - prev.total) / (next.count - prev.count) : 0;
-  }
-  return next.count - prev.count;
-}
-
-function showGcMetrics(unit, extraData, data) {
-  return extraData.label + ': ' + Math.round(data[0].measurements.find(x => x.statistic === extraData.prop)?.value) + unit;
-}
-
-function setGcPausesData(chart, dataPoints, type) {
-  const labels = chart.labels;
-
-
-  dataPoints.map((d) => {
-    if (!labels.includes(d[0].time)) {
-      const prev = chart.datasets[0].prevMeasurement;
-      labels.push(d[0].time);
-      if (prev) {
-        var dataPoint = getGcPausesData(d[0]);
-        const pt = {
-          time: d[0].time,
-          gc: formula(dataPoint, prev, type)
-        }
-        chart.datasets[0].prevMeasurement = dataPoint;
-        chart.datasets[0].data.push(pt);
-      }
+      },
+    };
+    let chartStatus = Chart.getChart("chart");
+    if (chartStatus === undefined) {
+      var memChart = new Chart(ctx, {
+        type: 'line',
+        data: data,
+        options: options
+      });
+      memChart.data.labels.shift();
     }
-  })
-}
+    var chart = Chart.getChart("chart");
 
-function getGcPausesData(data) {
-  const gcPause = {
-    total: data.measurements.find(x => x.statistic === 'TOTAL_TIME')?.value,
-    count: data.measurements.find(x => x.statistic === 'COUNT')?.value,
-    max: data.measurements.find(x => x.statistic === 'MAX')?.value
-  }
-  return gcPause;
-}
+    var datapoints = chart.data.datasets[0].data.length;
 
-function plotGcGraph(graphData, type, extraData, unit, label) {
-  var ctx = document.getElementById("chart").getContext("2d");
-  var dataset = {
-    label: label,
-    stacked: false,
-    backgroundColor: "#e86682",
-    borderColor: "#ed2d56",
-    fillColor: "#e86682",
-    data: [],
-    prevMeasurement: {},
-    parsing: {
-      xAxisKey: 'time',
-      yAxisKey: 'gc'
-    },
+    setMemoryData(chart.data, graphData, zones);
+
+    while (datapoints >= maxDataPoints) {
+      chart.data.labels.shift();
+      chart.data.datasets.forEach((d) => {
+        d.data.shift();
+      });
+      datapoints = datapoints - 1;
+    }
+
+    chart.update();
   }
 
-  var data = {
-    labels: [],
-    datasets: [dataset]
-  };
-  var options = {
-    animation: false,
-    maintainAspectRatio: false,
-    scales: {
-      x: {},
-      y: {
-        min: 0,
+
+  function formula(next, prev, type) {
+    if (type === "Gc Pauses") {
+      return next.count < prev.count ? 1000 * (next.total - prev.total) / (next.count - prev.count) : 0;
+    }
+    return next.count - prev.count;
+  }
+
+  function showGcMetrics(unit, extraData, data) {
+    return extraData.label + ': ' + Math.round(data[0].measurements.find(x => x.statistic === extraData.prop)?.value) + unit;
+  }
+
+  function setGcPausesData(chart, dataPoints, type) {
+    const labels = chart.labels;
+
+
+    dataPoints.map((d) => {
+      if (!labels.includes(d[0].time)) {
+        const prev = chart.datasets[0].prevMeasurement;
+        labels.push(d[0].time);
+        if (prev) {
+          var dataPoint = getGcPausesData(d[0]);
+          const pt = {
+            time: d[0].time,
+            gc: formula(dataPoint, prev, type)
+          }
+          chart.datasets[0].prevMeasurement = dataPoint;
+          chart.datasets[0].data.push(pt);
+        }
+      }
+    })
+  }
+
+  function getGcPausesData(data) {
+    const gcPause = {
+      total: data.measurements.find(x => x.statistic === 'TOTAL_TIME')?.value,
+      count: data.measurements.find(x => x.statistic === 'COUNT')?.value,
+      max: data.measurements.find(x => x.statistic === 'MAX')?.value
+    }
+    return gcPause;
+  }
+
+  function plotGcGraph(graphData, type, extraData, unit, label) {
+    var ctx = document.getElementById("chart").getContext("2d");
+    var dataset = {
+      label: label,
+      stacked: false,
+      backgroundColor: "#e86682",
+      borderColor: "#ed2d56",
+      fillColor: "#e86682",
+      data: [],
+      prevMeasurement: {},
+      parsing: {
+        xAxisKey: 'time',
+        yAxisKey: 'gc'
+      },
+    }
+
+    var data = {
+      labels: [],
+      datasets: [dataset]
+    };
+    var options = {
+      animation: false,
+      maintainAspectRatio: false,
+      scales: {
+        x: {},
+        y: {
+          min: 0,
+          title: {
+            display: true,
+            text: unit,
+            padding: -2,
+            labelOffset: -5
+          }
+        }
+      },
+      plugins: {
         title: {
           display: true,
-          text: unit,
-          padding: -2,
-          labelOffset: -5
+          position: "top",
+          text: ['Gc Pauses', showGcMetrics(unit, extraData, graphData[0])]
+        },
+        tooltip: {
+          mode: 'index'
+        },
+        interaction: {
+          mode: 'nearest',
+          axis: 'x',
+          intersect: false,
+        },
+        legend: {
+          display: true,
+          position: "bottom",
+          labels: {
+            boxHeight: 0,
+            boxWidth: 15
+          }
         }
-      }
-    },
-    plugins: {
-      title: {
-        display: true,
-        position: "top",
-        text: ['Gc Pauses', showGcMetrics(unit, extraData, graphData[0])]
       },
-      tooltip: {
-        mode: 'index'
-      },
-      interaction: {
-        mode: 'nearest',
-        axis: 'x',
-        intersect: false,
-      },
-      legend: {
-        display: true,
-        position: "bottom",
-        labels: {
-          boxHeight: 0,
-          boxWidth: 15
-        }
-      }
-    },
-  };
-  let chartStatus = Chart.getChart("chart");
-  if (chartStatus === undefined) {
-    var gcChart = new Chart(ctx, {
-      type: 'line',
-      data: data,
-      options: options
-    });
+    };
+    let chartStatus = Chart.getChart("chart");
+    if (chartStatus === undefined) {
+      var gcChart = new Chart(ctx, {
+        type: 'line',
+        data: data,
+        options: options
+      });
 
-    var gcPause = {
-      total: graphData[0][0].measurements.find(x => x.statistic === 'TOTAL_TIME')?.value,
-      count: graphData[0][0].measurements.find(x => x.statistic === 'COUNT')?.value,
-      max: graphData[0][0].measurements.find(x => x.statistic === 'MAX')?.value
+      var gcPause = {
+        total: graphData[0][0].measurements.find(x => x.statistic === 'TOTAL_TIME')?.value,
+        count: graphData[0][0].measurements.find(x => x.statistic === 'COUNT')?.value,
+        max: graphData[0][0].measurements.find(x => x.statistic === 'MAX')?.value
+      }
+      gcChart.data.datasets[0].prevMeasurement = gcPause
+      gcChart.data.labels.shift();
     }
-    gcChart.data.datasets[0].prevMeasurement = gcPause
-    gcChart.data.labels.shift();
+
+    var chart = Chart.getChart("chart");
+
+    var datapoints = chart.data.datasets[0].data.length;
+
+    setGcPausesData(chart.data, graphData, type);
+
+    while (datapoints >= maxDataPoints) {
+      chart.data.labels.shift();
+      chart.data.datasets[0].data.shift();
+      datapoints = datapoints - 1;
+    }
+
+    chart.update();
+
   }
 
-  var chart = Chart.getChart("chart");
-
-  var datapoints = chart.data.datasets[0].data.length;
-
-  setGcPausesData(chart.data, graphData, type);
-
-  while (datapoints >= maxDataPoints) {
-    chart.data.labels.shift();
-    chart.data.datasets[0].data.shift();
-    datapoints = datapoints - 1;
-  }
-
-  chart.update();
-
-}
-
+}())

--- a/src/controllers/LiveDataController.ts
+++ b/src/controllers/LiveDataController.ts
@@ -64,7 +64,9 @@ async function updateProcessInfo(payload: string | LocalLiveProcess) {
     appsProvider.refresh(undefined);
 
     // memory view
-    // memoryProvider.refreshLiveMetrics(liveProcess, "heap", []);
+    memoryProvider.refreshLiveMetrics(liveProcess, "heap", []);
+    memoryProvider.refreshLiveMetrics(liveProcess, "non-heap", []);
+    memoryProvider.refreshLiveMetrics(liveProcess, "gc-pauses", []);
 }
 
 async function updateProcessGcPausesMetrics(payload: string | LocalLiveProcess) {
@@ -74,7 +76,6 @@ async function updateProcessGcPausesMetrics(payload: string | LocalLiveProcess) 
     const gcPauses = await getGcPausesMetrics(processKey);
     if (gcPauses) {
         memoryProvider.refreshLiveMetrics(liveProcess, "gc-pauses", gcPauses);
-        store.data.set(processKey, { gcPauses });
     }
 }
 
@@ -85,11 +86,14 @@ async function updateProcessMemoryMetrics(payload: string | LocalLiveProcess) {
     const heapMemMetrics = await getMemoryMetrics(processKey, "heapMemory");
     const nonHeapMemMetrics = await getMemoryMetrics(processKey, "nonHeapMemory");
 
+    if (!store.data.has(processKey)) {
+        return;
+    }
+
     if (heapMemMetrics || nonHeapMemMetrics) {
         await vscode.commands.executeCommand("setContext", "spring.memoryGraphs:hasLiveProcess", liveProcess !== undefined);
         memoryProvider.refreshLiveMetrics(liveProcess, "heap", heapMemMetrics);
         memoryProvider.refreshLiveMetrics(liveProcess, "non-heap", nonHeapMemMetrics);
-        store.data.set(processKey, { heapMemMetrics, nonHeapMemMetrics });
     }
 }
 

--- a/src/controllers/LiveDataController.ts
+++ b/src/controllers/LiveDataController.ts
@@ -62,6 +62,9 @@ async function updateProcessInfo(payload: string | LocalLiveProcess) {
         runningApp.state = AppState.RUNNING; // will refresh tree item
     }
     appsProvider.refresh(undefined);
+
+    // memory view
+    // memoryProvider.refreshLiveMetrics(liveProcess, "heap", []);
 }
 
 async function updateProcessGcPausesMetrics(payload: string | LocalLiveProcess) {
@@ -70,7 +73,7 @@ async function updateProcessGcPausesMetrics(payload: string | LocalLiveProcess) 
 
     const gcPauses = await getGcPausesMetrics(processKey);
     if (gcPauses) {
-        memoryProvider.refreshLiveGcPausesMetrics(liveProcess, gcPauses);
+        memoryProvider.refreshLiveMetrics(liveProcess, "gc-pauses", gcPauses);
         store.data.set(processKey, { gcPauses });
     }
 }
@@ -84,8 +87,8 @@ async function updateProcessMemoryMetrics(payload: string | LocalLiveProcess) {
 
     if (heapMemMetrics || nonHeapMemMetrics) {
         await vscode.commands.executeCommand("setContext", "spring.memoryGraphs:hasLiveProcess", liveProcess !== undefined);
-        memoryProvider.refreshLiveHeapMemoryMetrics(liveProcess, heapMemMetrics);
-        memoryProvider.refreshLiveNonHeapMemoryMetrics(liveProcess, nonHeapMemMetrics);
+        memoryProvider.refreshLiveMetrics(liveProcess, "heap", heapMemMetrics);
+        memoryProvider.refreshLiveMetrics(liveProcess, "non-heap", nonHeapMemMetrics);
         store.data.set(processKey, { heapMemMetrics, nonHeapMemMetrics });
     }
 }
@@ -95,9 +98,9 @@ async function resetProcessInfo(payload: string | LocalLiveProcess) {
     store.data.delete(liveProcess.processKey);
     beansProvider.refreshLive(liveProcess, undefined);
     mappingsProvider.refreshLive(liveProcess, undefined);
-    memoryProvider.refreshLiveGcPausesMetrics(liveProcess, undefined);
-    memoryProvider.refreshLiveHeapMemoryMetrics(liveProcess, undefined);
-    memoryProvider.refreshLiveNonHeapMemoryMetrics(liveProcess, undefined);
+    memoryProvider.refreshLiveMetrics(liveProcess, "heap", undefined);
+    memoryProvider.refreshLiveMetrics(liveProcess, "non-heap", undefined);
+    memoryProvider.refreshLiveMetrics(liveProcess, "gc-pauses", undefined);
     await vscode.commands.executeCommand("setContext", "spring.memoryGraphs:hasLiveProcess", store.data.size > 0);
     const disconnectedApp = appsProvider.manager.getAppByPid(liveProcess.pid);
     // Workaound for: app is still running if manually disconnect from live process connection.


### PR DESCRIPTION
Root cause is race condition of upstream api calls. After live connection disconnected, previous call for metrics returns.

Now status of process is set only on connected/disconnected. outdated metrics will be discarded.