### PR TITLE
query for memory metrics on process connect/update

### DIFF
--- a/src/controllers/LiveDataController.ts
+++ b/src/controllers/LiveDataController.ts
@@ -2,7 +2,7 @@ import * as vscode from "vscode";
 import { sendInfo } from "vscode-extension-telemetry-wrapper";
 import { AppState } from "../BootApp";
 import { dashboard } from "../global";
-import { getBeans, getContextPath, getMainClass, getMappings, getPid, getPort, getGcPausesMetrics, getMemoryMetrics, initialize } from "../models/stsApi";
+import { getBeans, getContextPath, getMainClass, getMappings, getPid, getPort, getGcPausesMetrics, getMemoryMetrics, initialize, refreshMetrics } from "../models/stsApi";
 import { LiveProcess } from "../types/sts-api";
 import { isAlive } from "../utils";
 
@@ -72,7 +72,8 @@ async function updateProcessInfo(payload: string | LiveProcess) {
     // See https://github.com/microsoft/vscode-spring-boot-dashboard/issues/287
     // send a memory metrics request, ensuring following notification comes
     if (type === "local") {
-        await updateProcessMemoryMetrics(payload);
+        await refreshMetrics(processKey, "memory");
+        // await updateProcessMemoryMetrics(payload);
     }
 }
 

--- a/src/models/stsApi.ts
+++ b/src/models/stsApi.ts
@@ -81,6 +81,17 @@ export async function getMemoryMetrics(processKey: string, memory: string) {
     return "";
 }
 
+export async function refreshMetrics(processKey: string, metricName: string) {
+    if (typeof stsApi?.refreshLiveProcessMetricsData === "function") {
+        await stsApi?.refreshLiveProcessMetricsData({
+            processKey: processKey,
+            endpoint: "metrics",
+            metricName: metricName,
+        });
+    }
+    return "";
+}
+
 export async function getPort(processKey: string) {
     const result = await stsApi?.getLiveProcessData({
         processKey: processKey,

--- a/src/views/memory.ts
+++ b/src/views/memory.ts
@@ -4,7 +4,7 @@
 
 import * as vscode from "vscode";
 import { LiveProcess } from "../models/liveProcess";
-import { stsApi } from "../models/stsApi";
+import { refreshMetrics } from "../models/stsApi";
 import * as sts from "../types/sts-api";
 
 interface Measurement {
@@ -144,18 +144,8 @@ export class MemoryViewProvider implements vscode.WebviewViewProvider {
             switch (command) {
                 case "LoadMetrics":
                     if (processKey !== '' && processKey !== undefined) {
-                        await stsApi?.refreshLiveProcessMetricsData({
-                            processKey: processKey,
-                            endpoint: "metrics",
-                            metricName: "memory",
-                        });
-
-                        await stsApi?.refreshLiveProcessMetricsData({
-                            processKey: processKey,
-                            endpoint: "metrics",
-                            metricName: "gcPauses",
-                            tags: ""
-                        });
+                        await refreshMetrics(processKey, "memory");
+                        await refreshMetrics(processKey, "gcPauses");
                     }
                     break;
                 case "LoadProcess":


### PR DESCRIPTION
@Eskibear 
As you mentioned in #293, the NullPointerException is due to the sequence of calling the metric APIs.

The [refreshLiveProcessMemoryData API](https://github.com/vudayani-vmw/vscode-spring-boot-dashboard/blob/868e02eb1a15e1ca3e80115552e2c05696cf0b2a/src/models/stsApi.ts#LL86C9-L90C12) queries the memory metrics data and sends the notification (`onDidLiveProcessMemoryMetricsUpdate`) when metrics data is available. The [updateProcessMemoryMetrics](https://github.com/vudayani-vmw/vscode-spring-boot-dashboard/blob/868e02eb1a15e1ca3e80115552e2c05696cf0b2a/src/controllers/LiveDataController.ts#LL90-L95C83) is invoked to fetch the memory metrics live data object. Since we are trying to fetch the memory metrics object before the metrics data is available, it results in the NullPointerException.

To avoid this race condition, we call the refreshLiveProcessMemoryData [API](https://github.com/vudayani-vmw/vscode-spring-boot-dashboard/blob/868e02eb1a15e1ca3e80115552e2c05696cf0b2a/src/controllers/LiveDataController.ts#LL75C8-L75C52) to query for the memory metrics before trying to [fetch](https://github.com/microsoft/vscode-spring-boot-dashboard/blob/63f9ace351b75ded9ce4404e5319374012f54b3c/src/controllers/LiveDataController.ts#L72-L76) and display them in the memory view.

This will also align with changes on the Language server side related to https://github.com/spring-projects/sts4/issues/1003.
`vscode-spring-boot-dashboard` queries for metrics data on live process connect.