### PR TITLE
Resolve url using codespace location

### DIFF
--- a/src/LocalAppController.ts
+++ b/src/LocalAppController.ts
@@ -248,7 +248,9 @@ export class LocalAppController {
             const openWithExternalBrowser: boolean = vscode.workspace.getConfiguration("spring.dashboard").get("openWith") === "external";
             const browserCommand: string = openWithExternalBrowser ? "vscode.open" : "simpleBrowser.api.open";
 
-            vscode.commands.executeCommand(browserCommand, vscode.Uri.parse(openUrl));
+            let uri = vscode.Uri.parse(openUrl);
+            uri = await vscode.env.asExternalUri(uri); // Enables Remote envs like Codespaces
+            vscode.commands.executeCommand(browserCommand, uri);
         } else {
             vscode.window.showErrorMessage("Couldn't determine port app is running on");
         }


### PR DESCRIPTION
When I use the springboot-dashboard extension in codespace and click the browser button for a selected App, it opens a localhost URL. To fix this issue, we need to open the URL with the remote environment’s location instead.

![image](https://user-images.githubusercontent.com/14052197/234166289-94003285-36ec-4d41-822b-c1ffcd33b05f.png)
