### PR TITLE
Spring profiles not detected if the source paths doesn't have files o…

### DIFF
--- a/src/LocalAppController.ts
+++ b/src/LocalAppController.ts
@@ -91,15 +91,19 @@ export class LocalAppController {
         const profilePattern = /^application-(.*).(properties|yml|yaml)$/;
         const detectedProfiles = [];
         for (const sf of sourceFolders) {
-            const uri = vscode.Uri.file(sf);
-            const entries = await vscode.workspace.fs.readDirectory(uri);
-            const files = entries.filter(f => f[1] === vscode.FileType.File);
-            for (const f of files) {
-                const res = profilePattern.exec(f[0]);
-                if (res !== null) {
-                    const matchedProfile = res[1];
-                    detectedProfiles.push(matchedProfile);
+            try {
+                const uri = vscode.Uri.file(sf);
+                const entries = await vscode.workspace.fs.readDirectory(uri);
+                const files = entries.filter(f => f[1] === vscode.FileType.File);
+                for (const f of files) {
+                    const res = profilePattern.exec(f[0]);
+                    if (res !== null) {
+                        const matchedProfile = res[1];
+                        detectedProfiles.push(matchedProfile);
+                    }
                 }
+            } catch (error) {
+                console.log(error);
             }
         }
         const selectedProfiles = await vscode.window.showQuickPick(detectedProfiles, {


### PR DESCRIPTION
Fixes #317 

Short-circuits the error if the file/folder path of the source paths doesn't exist.

In below image, the **src/test/java** (EDITED from **src/test/resources**) folder doesn't exist and after fix, it loads the local profile

![image](https://github.com/microsoft/vscode-spring-boot-dashboard/assets/12153250/d71f0034-3eb8-4161-baed-1461419560ad)
