### PR TITLE
#320 Show active profiles on BootApp description when attached to liv…

### DIFF
--- a/src/BootApp.ts
+++ b/src/BootApp.ts
@@ -21,7 +21,7 @@ export class BootApp {
     private _port?: number;
     private _contextPath?: string;
     private _pid?: number;
-    private _activeProfiles?: string;
+    private _activeProfiles?: string[];
 
     private _watchdog?: NodeJS.Timeout; // used to watch running process.
 
@@ -106,16 +106,12 @@ export class BootApp {
         }
     }
 
-    public get activeProfiles(): string | undefined {
+    public get activeProfiles(): string[] | undefined {
         return this._activeProfiles;
     }
 
-    public set activeProfiles(value: string | undefined) {
-        if(value?.length) {
-            this._activeProfiles = value.split(",").join(", ");
-        } else {
-            this._activeProfiles = value;
-        }
+    public set activeProfiles(profiles: string[] | undefined) {
+        this._activeProfiles = profiles;
     }
 
     public get contextPath(): string | undefined {

--- a/src/BootApp.ts
+++ b/src/BootApp.ts
@@ -111,7 +111,11 @@ export class BootApp {
     }
 
     public set activeProfiles(value: string | undefined) {
-        this._activeProfiles = value || 'default';
+        if(value?.length) {
+            this._activeProfiles = value.split(",").join(", ");
+        } else {
+            this._activeProfiles = value;
+        }
     }
 
     public get contextPath(): string | undefined {

--- a/src/BootApp.ts
+++ b/src/BootApp.ts
@@ -21,6 +21,7 @@ export class BootApp {
     private _port?: number;
     private _contextPath?: string;
     private _pid?: number;
+    private _activeProfiles?: string;
 
     private _watchdog?: NodeJS.Timeout; // used to watch running process.
 
@@ -105,6 +106,14 @@ export class BootApp {
         }
     }
 
+    public get activeProfiles(): string | undefined {
+        return this._activeProfiles;
+    }
+
+    public set activeProfiles(value: string | undefined) {
+        this._activeProfiles = value || 'default';
+    }
+
     public get contextPath(): string | undefined {
         return this._contextPath;
     }
@@ -133,6 +142,7 @@ export class BootApp {
         this._contextPath = undefined;
         this.pid = undefined;
         this._state = AppState.INACTIVE;
+        this._activeProfiles = undefined;
         dashboard.appsProvider.refresh(this);  // TODO: should do it in LocalAppController.
     }
 

--- a/src/LocalAppController.ts
+++ b/src/LocalAppController.ts
@@ -67,6 +67,7 @@ export class LocalAppController {
             targetConfig = await this._createNewLaunchConfig(mainClasData);
         }
         app.activeSessionName = targetConfig.name;
+        app.activeProfiles = profile;
 
         targetConfig = await resolveDebugConfigurationWithSubstitutedVariables(targetConfig);
         app.jmxPort = parseJMXPort(targetConfig.vmArgs);

--- a/src/LocalAppController.ts
+++ b/src/LocalAppController.ts
@@ -67,7 +67,6 @@ export class LocalAppController {
             targetConfig = await this._createNewLaunchConfig(mainClasData);
         }
         app.activeSessionName = targetConfig.name;
-        app.activeProfiles = profile;
 
         targetConfig = await resolveDebugConfigurationWithSubstitutedVariables(targetConfig);
         app.jmxPort = parseJMXPort(targetConfig.vmArgs);

--- a/src/controllers/LiveDataController.ts
+++ b/src/controllers/LiveDataController.ts
@@ -68,7 +68,6 @@ async function updateProcessInfo(payload: string | LiveProcessPayload) {
             runningApp.port = parseInt(port);
             runningApp.contextPath = contextPath;
             runningApp.state = AppState.RUNNING; // will refresh tree item
-            runningApp.activeProfiles = await lp.getActiveProfilesFromLiveProcess();
         }
     }
 

--- a/src/controllers/LiveDataController.ts
+++ b/src/controllers/LiveDataController.ts
@@ -68,6 +68,7 @@ async function updateProcessInfo(payload: string | LiveProcessPayload) {
             runningApp.port = parseInt(port);
             runningApp.contextPath = contextPath;
             runningApp.state = AppState.RUNNING; // will refresh tree item
+            runningApp.activeProfiles = await lp.getActiveProfilesFromLiveProcess();
         }
     }
 

--- a/src/controllers/LiveDataController.ts
+++ b/src/controllers/LiveDataController.ts
@@ -3,7 +3,7 @@ import { sendInfo } from "vscode-extension-telemetry-wrapper";
 import { AppState } from "../BootApp";
 import { dashboard } from "../global";
 import { LiveProcess } from "../models/liveProcess";
-import { getBeans, getContextPath, getMainClass, getMappings, getPid, getPort, getGcPausesMetrics, getMemoryMetrics, initialize, refreshMetrics } from "../models/stsApi";
+import { getBeans, getContextPath, getMainClass, getMappings, getPid, getPort, getGcPausesMetrics, getMemoryMetrics, initialize, refreshMetrics, getActiveProfiles } from "../models/stsApi";
 import { LiveProcessPayload } from "../types/sts-api";
 import { isAlive } from "../utils";
 
@@ -58,6 +58,7 @@ async function updateProcessInfo(payload: string | LiveProcessPayload) {
     dashboard.mappingsProvider.refreshLive(liveProcess, mappings);
 
     const port = await getPort(processKey);
+    const activeProfiles = await getActiveProfiles(processKey);
     const contextPath = await getContextPath(processKey);
     const lp = new LiveProcess(liveProcess);
     store.data.set(processKey, lp);
@@ -66,6 +67,7 @@ async function updateProcessInfo(payload: string | LiveProcessPayload) {
         const runningApp = dashboard.appsProvider.manager.getAppByPid(liveProcess.pid);
         if (runningApp) {
             runningApp.port = parseInt(port);
+            runningApp.activeProfiles = activeProfiles;
             runningApp.contextPath = contextPath;
             runningApp.state = AppState.RUNNING; // will refresh tree item
         }

--- a/src/models/liveProcess.ts
+++ b/src/models/liveProcess.ts
@@ -88,10 +88,4 @@ export class LiveProcess {
         }
         return this.propertyGroups;
     }
-
-    public async getActiveProfilesFromLiveProcess(): Promise<string | undefined> {
-        const liveProcessProperties = await this.getProperties();
-        const systemProperties = liveProcessProperties?.find(pg => pg.name === 'systemProperties');
-        return systemProperties?.properties.find(p => p.name === 'spring.profiles.active')?.value;
-    }
 }

--- a/src/models/liveProcess.ts
+++ b/src/models/liveProcess.ts
@@ -88,4 +88,10 @@ export class LiveProcess {
         }
         return this.propertyGroups;
     }
+
+    public async getActiveProfilesFromLiveProcess(): Promise<string | undefined> {
+        const liveProcessProperties = await this.getProperties();
+        const systemProperties = liveProcessProperties?.find(pg => pg.name === 'systemProperties');
+        return systemProperties?.properties.find(p => p.name === 'spring.profiles.active')?.value;
+    }
 }

--- a/src/models/stsApi.ts
+++ b/src/models/stsApi.ts
@@ -194,3 +194,12 @@ export async function requestWorkspaceSymbolsByQuery(query: string): Promise<lsp
     const res = await stsApi?.client.sendRequest<lsp.SymbolInformation[]>("workspace/symbol", { "query": query }) ?? [];
     return res;
 }
+
+export async function getActiveProfiles(processKey: string) {
+    const result = await stsApi?.getLiveProcessData({
+        processKey: processKey,
+        endpoint: "profiles"
+    }) as string[];
+    
+    return result;
+}

--- a/src/types/sts-api.d.ts
+++ b/src/types/sts-api.d.ts
@@ -65,7 +65,7 @@ interface LiveProcessDataQuery {
 }
 
 interface SimpleQuery extends LiveProcessDataQuery {
-    endpoint: "mappings" | "contextPath" | "port" | "properties";
+    endpoint: "mappings" | "contextPath" | "port" | "properties" | "profiles";
 }
 
 interface BeansQuery extends LiveProcessDataQuery {

--- a/src/views/items/BootAppItem.ts
+++ b/src/views/items/BootAppItem.ts
@@ -34,8 +34,8 @@ export class BootAppItem implements vscode.TreeItem {
         if (this._app.contextPath) {
             list.push(this._app.contextPath);
         }
-        if(this._app.activeProfiles) {
-            const profileInfo = `profiles: '${this._app.activeProfiles}'`
+        if(this._app.activeProfiles?.length) {
+            const profileInfo = `profiles: '${this._app.activeProfiles.join(", ")}'`
             list.push(profileInfo);
         }
         if (list.length > 0) {

--- a/src/views/items/BootAppItem.ts
+++ b/src/views/items/BootAppItem.ts
@@ -34,6 +34,10 @@ export class BootAppItem implements vscode.TreeItem {
         if (this._app.contextPath) {
             list.push(this._app.contextPath);
         }
+        if(this._app.activeProfiles) {
+            const profileInfo = `profiles: '${this._app.activeProfiles}'`
+            list.push(profileInfo);
+        }
         if (list.length > 0) {
             return `[${list.join(", ")}]`;
         }

--- a/src/views/items/BootAppItem.ts
+++ b/src/views/items/BootAppItem.ts
@@ -35,7 +35,7 @@ export class BootAppItem implements vscode.TreeItem {
             list.push(this._app.contextPath);
         }
         if(this._app.activeProfiles) {
-            const profileInfo = `profiles: '${this._app.activeProfiles}'`
+            const profileInfo = `profile(s): '${this._app.activeProfiles}'`
             list.push(profileInfo);
         }
         if (list.length > 0) {

--- a/src/views/items/BootAppItem.ts
+++ b/src/views/items/BootAppItem.ts
@@ -35,7 +35,7 @@ export class BootAppItem implements vscode.TreeItem {
             list.push(this._app.contextPath);
         }
         if(this._app.activeProfiles) {
-            const profileInfo = `profile(s): '${this._app.activeProfiles}'`
+            const profileInfo = `profiles: '${this._app.activeProfiles}'`
             list.push(profileInfo);
         }
         if (list.length > 0) {


### PR DESCRIPTION
Addresses improvement of #320 .

The changes include updating the BootApp description along with the `systemProperty` => `spring.profiles.active`.

Inline with the previous logic to display the other description items like `contextPath` and `port`, the property values need to be exposed for the IDE to display the comma separated profiles instead of astericks (****)

**Quick video of how it works**:

https://github.com/microsoft/vscode-spring-boot-dashboard/assets/12153250/b642fd76-272b-41ac-baca-6a012b91214f

