### PR TITLE
Fix spinning wheel in boot apps view

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -74,7 +74,7 @@ export async function initializeExtension(_oprationId: string, context: vscode.E
     });
     vscode.debug.onDidReceiveDebugSessionCustomEvent(e => {
         if (e.session.type === 'java' && e.event === 'processid') {
-            const app = appsProvider.manager.getAppList().find(app => app.mainClasses.find(mc => mc.mainClass === e.session.configuration.mainClass));
+            const app = appsProvider.manager.getAppList().find(app => app.name === e.session.configuration.projectName);
             if (app) {
                 app.pid = parseInt(e.body.processId);
             }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -74,7 +74,7 @@ export async function initializeExtension(_oprationId: string, context: vscode.E
     });
     vscode.debug.onDidReceiveDebugSessionCustomEvent(e => {
         if (e.session.type === 'java' && e.event === 'processid') {
-            const app = appsProvider.manager.getAppList().find(app => app.activeSessionName === e.session.name);
+            const app = appsProvider.manager.getAppList().find(app => app.mainClasses.find(mc => mc.mainClass === e.session.configuration.mainClass));
             if (app) {
                 app.pid = parseInt(e.body.processId);
             }

--- a/src/views/memory.ts
+++ b/src/views/memory.ts
@@ -153,7 +153,7 @@ export class MemoryViewProvider implements vscode.WebviewViewProvider {
                 case "FetchData": {
                     const type = message.type;
                     if (processKey === '') {
-                        processKey = this.storeLiveProcesses.values().next().value.liveProcess.processKey;
+                        processKey = this.storeLiveProcesses.values().next().value.liveProcess?.processKey;
                     }
                     if (type !== '' && type === "Heap Memory" && processKey !== undefined && processKey !== '') {
                         const targetLiveProcess = Array.from(this.storeHeapMemoryMetrics.keys()).find(lp => lp.processKey === processKey) ?? new LiveProcess(processKey);


### PR DESCRIPTION
Try to match custom debug event against project name in `BootApp` and `DebugSession`.
The fix in memory provider is just to avoid errors in the console

Fixes #216 