### PR TITLE
feat(#336): ✨ use cwd from launch config

### DIFF
--- a/src/LocalAppController.ts
+++ b/src/LocalAppController.ts
@@ -78,7 +78,8 @@ export class LocalAppController {
             launchConfig.vmArgs = launchConfig.vmArgs + ` -Dspring.profiles.active=${profile}`;
         }
 
-        const cwdUri: vscode.Uri = vscode.Uri.parse(launchConfig.cwd);
+
+        const cwdUri: vscode.Uri = vscode.Uri.parse(app.path);
         await vscode.debug.startDebugging(
             vscode.workspace.getWorkspaceFolder(cwdUri),
             launchConfig

--- a/src/LocalAppController.ts
+++ b/src/LocalAppController.ts
@@ -71,15 +71,14 @@ export class LocalAppController {
         targetConfig = await resolveDebugConfigurationWithSubstitutedVariables(targetConfig);
         app.jmxPort = parseJMXPort(targetConfig.vmArgs);
 
-        const cwdUri: vscode.Uri = vscode.Uri.parse(app.path);
         const launchConfig = Object.assign({}, targetConfig, {
-            noDebug: !debug,
-            cwd: cwdUri.fsPath,
+            noDebug: !debug
         });
         if (profile) {
             launchConfig.vmArgs = launchConfig.vmArgs + ` -Dspring.profiles.active=${profile}`;
         }
 
+        const cwdUri: vscode.Uri = vscode.Uri.parse(launchConfig.cwd);
         await vscode.debug.startDebugging(
             vscode.workspace.getWorkspaceFolder(cwdUri),
             launchConfig


### PR DESCRIPTION
Addresses #336, which makes the working directory of a boot application configurable.

I have referred to the cwd property of the generated launchconfig and no longer overwrite it with the app path.
This allows the working directory to be adapted to the own requirements.