### PR TITLE
Add support for running the projects with Gradle, instead of the redhat.java JDT build

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ Spring Boot Dashboard is a lightweight extension in Visual Studio Code (VS Code)
 * View Spring Boot apps in workspace
 * Start / Stop a Spring Boot app
 * Debug a Spring Boot app
+* Delegate local Run / Debug / Stop actions to Gradle tasks
 * Open a Spring Boot app in browser
 * List beans/endpoint mappings
 * View bean dependencies
@@ -38,6 +39,17 @@ ext install vscode-spring-boot-dashboard
 - View all available Spring Boot apps in current workspace
 - Right click on a certain app and choose to start, stop or debug it
 - Right click on a certain app and open the website in a browser
+
+## Gradle launch strategy
+
+Spring Boot Dashboard can now launch local apps through either the default Java debugger flow or delegated Gradle tasks.
+
+Set `spring.dashboard.launchStrategy` to `gradle` to have Run / Debug / Stop actions execute Gradle tasks instead of VS Code's Java launch flow.
+
+- `spring.dashboard.gradle.task`: Gradle task used for Run, defaults to `bootRun`
+- `spring.dashboard.gradle.debugTask`: optional Gradle task used for Debug; if empty, the Run task is reused
+
+Both plain task names such as `bootRun` and fully qualified task paths such as `:service:bootRun` are supported. The dashboard will use the Gradle wrapper when available, and otherwise falls back to a `gradle` executable on your `PATH`.
 
 ## Data/Telemetry
 VS Code collects usage data and sends it to Microsoft to help improve our products and services. Read our [privacy statement](http://go.microsoft.com/fwlink/?LinkId=521839) to learn more. If you don’t wish to send usage data to Microsoft, you can set the `telemetry.enableTelemetry` setting to `false`. Learn more in our [FAQ](https://code.visualstudio.com/docs/supporting/faq#_how-to-disable-telemetry-reporting).

--- a/package.json
+++ b/package.json
@@ -567,6 +567,32 @@
       {
         "title": "Spring Boot Dashboard",
         "properties": {
+          "spring.dashboard.launchStrategy": {
+            "default": "java",
+            "type": "string",
+            "enum": [
+              "java",
+              "gradle"
+            ],
+            "enumDescriptions": [
+              "Launch Spring Boot apps using the Java debugger's launch configuration flow.",
+              "Delegate local Spring Boot Run/Debug/Stop actions to Gradle tasks."
+            ],
+            "scope": "window",
+            "description": "Defines how local Spring Boot apps are started from the dashboard."
+          },
+          "spring.dashboard.gradle.task": {
+            "default": "bootRun",
+            "type": "string",
+            "scope": "window",
+            "description": "Gradle task used when launchStrategy is set to gradle. Supports plain task names such as bootRun and fully qualified task paths such as :service:bootRun."
+          },
+          "spring.dashboard.gradle.debugTask": {
+            "default": "",
+            "type": "string",
+            "scope": "window",
+            "description": "Optional Gradle task used for Debug when launchStrategy is set to gradle. If empty, spring.dashboard.gradle.task is reused."
+          },
           "spring.dashboard.openWith": {
             "default": "integrated",
             "type": "string",

--- a/src/BootApp.ts
+++ b/src/BootApp.ts
@@ -3,6 +3,7 @@
 
 import * as vscode from "vscode";
 import { dashboard } from "./global";
+import { DebugSessionRole, GradleLaunchPhase, LaunchStrategy } from "./launchUtils";
 import { requestWorkspaceSymbols } from "./models/stsApi";
 import { ClassPathData, MainClassData } from "./types/jdtls";
 import { isActuatorJarFile, isAlive } from "./utils";
@@ -25,6 +26,21 @@ export enum AppState {
     RUNNING = 'running'
 }
 
+export interface GradleLaunchState {
+    launchStrategy: LaunchStrategy;
+    pendingMainClass?: string;
+    taskExecution?: vscode.TaskExecution;
+    taskPath?: string;
+    taskId?: string;
+    jmxPort?: number;
+    debugPort?: number;
+    attachSessionName?: string;
+    attachSessionId?: string;
+    initScriptUri?: vscode.Uri;
+    phase: GradleLaunchPhase;
+    sessionRole?: DebugSessionRole;
+}
+
 export class BootApp {
     private _activeSessionName?: string;
     private _jmxPort?: number;
@@ -32,6 +48,11 @@ export class BootApp {
     private _contextPath?: string;
     private _pid?: number;
     private _activeProfiles?: string[];
+    private _launchStrategy: LaunchStrategy = "java";
+    private _gradleLaunch: GradleLaunchState = {
+        launchStrategy: "java",
+        phase: "idle",
+    };
 
     private _watchdog?: NodeJS.Timeout; // used to watch running process.
 
@@ -122,6 +143,33 @@ export class BootApp {
 
     public set activeProfiles(profiles: string[] | undefined) {
         this._activeProfiles = profiles;
+    }
+
+    public get launchStrategy(): LaunchStrategy {
+        return this._launchStrategy;
+    }
+
+    public set launchStrategy(strategy: LaunchStrategy) {
+        this._launchStrategy = strategy;
+    }
+
+    public get gradleLaunch(): GradleLaunchState {
+        return this._gradleLaunch;
+    }
+
+    public set gradleLaunch(launch: GradleLaunchState) {
+        this._gradleLaunch = launch;
+    }
+
+    public clearGradleLaunch(): void {
+        this._gradleLaunch = {
+            launchStrategy: "java",
+            phase: "idle",
+        };
+    }
+
+    public get hasActiveGradleLaunch(): boolean {
+        return this._gradleLaunch.phase !== "idle" || this._gradleLaunch.taskExecution !== undefined;
     }
 
     public get contextPath(): string | undefined {

--- a/src/LocalAppController.ts
+++ b/src/LocalAppController.ts
@@ -6,20 +6,64 @@ import { ChildProcess } from "child_process";
 import * as path from "path";
 import * as vscode from "vscode";
 import { AppState, BootApp } from "./BootApp";
+import { dashboard } from "./global";
+import {
+    buildDashboardJvmArgs,
+    createAttachDebugConfiguration,
+    createGradleInitScript,
+    ensureDashboardVmArgs,
+    getConfiguredGradleTask,
+    getGradleStorageDir,
+    getWorkspaceLaunchStrategy,
+    GradleContext,
+    normalizeLaunchStrategy,
+    resolveGradleContext,
+    SPRING_DASHBOARD_APP_PATH,
+    SPRING_DASHBOARD_SESSION_ROLE,
+    waitForPort,
+} from "./launchUtils";
 import { LocalAppManager } from "./LocalAppManager";
 import { MainClassData } from "./types/jdtls";
-import { constructOpenUrl, isActuatorJarFile, readAll } from "./utils";
+import { constructOpenUrl, isActuatorJarFile, isAlive, readAll, sleep } from "./utils";
 
 import getPort = require("get-port");
 import { sendInfo } from "vscode-extension-telemetry-wrapper";
-import { dashboard } from "./global";
 
-export class LocalAppController {
+const GRADLE_TASK_TYPE = "spring-boot-dashboard-gradle";
+const GRADLE_TASK_SOURCE = "Spring Boot Dashboard";
+const GRADLE_TASK_START_TIMEOUT_MS = 15000;
+const GRADLE_ATTACH_TIMEOUT_MS = 30000;
+const GRADLE_STOP_GRACE_PERIOD_MS = 2000;
+
+interface GradleTaskDefinition extends vscode.TaskDefinition {
+    appPath: string;
+    launchId: string;
+}
+
+export class LocalAppController implements vscode.Disposable {
+    private readonly disposables: vscode.Disposable[] = [];
 
     constructor(
         private manager: LocalAppManager,
         private context: vscode.ExtensionContext
-    ) { }
+    ) {
+        this.disposables.push(
+            vscode.tasks.onDidEndTaskProcess((event) => {
+                void this._handleGradleTaskProcessEnd(event);
+            }),
+            vscode.tasks.onDidEndTask((event) => {
+                void this._handleGradleTaskEnd(event);
+            })
+        );
+    }
+
+    public dispose(): void {
+        while (this.disposables.length > 0) {
+            const disposable = this.disposables.pop();
+            disposable?.dispose();
+        }
+        void this._cleanupGradleStorageDir();
+    }
 
     public getAppList(): BootApp[] {
         return this.manager.getAppList();
@@ -28,11 +72,11 @@ export class LocalAppController {
     public async runBootApps(debug?: boolean) {
         const appList = this.getAppList();
         if (appList.length === 1 && appList[0].state !== AppState.RUNNING) {
-            this.runBootApp(appList[0], debug);
+            await this.runBootApp(appList[0], debug);
         } else {
             const appsToRun = await vscode.window.showQuickPick(
-                appList.filter(app => app.state !== AppState.RUNNING).map(app => ({ label: app.name, path: app.path })), /** items */
-                { canPickMany: true, placeHolder: `Select apps to ${debug ? "debug" : "run"}.` } /** options */
+                appList.filter(app => app.state !== AppState.RUNNING).map(app => ({ label: app.name, path: app.path })),
+                { canPickMany: true, placeHolder: `Select apps to ${debug ? "debug" : "run"}.` }
             );
             if (appsToRun !== undefined) {
                 const appPaths = appsToRun.map(elem => elem.path);
@@ -42,48 +86,18 @@ export class LocalAppController {
     }
 
     public async runBootApp(app: BootApp, debug?: boolean, profile?: string): Promise<void> {
-        const mainClasData = await vscode.window.withProgress(
-            { location: vscode.ProgressLocation.Window, title: `Resolving main classes for ${app.name}...` },
-            async () => {
-                const mainClassList = await app.getMainClasses();
-
-                if (mainClassList && mainClassList instanceof Array && mainClassList.length > 0) {
-                    return mainClassList.length === 1 ? mainClassList[0] :
-                        await vscode.window.showQuickPick(mainClassList.map(x => Object.assign({ label: x.mainClass }, x)), { placeHolder: `Specify the main class for ${app.name}` });
-                }
-                return null;
-            }
-        );
-        if (mainClasData === null) {
-            vscode.window.showWarningMessage("No main class is found.");
-            return;
-        }
-        if (mainClasData === undefined) {
+        const mainClassData = await this._resolveMainClass(app);
+        if (mainClassData === undefined) {
             return;
         }
 
-        let targetConfig = this._getLaunchConfig(mainClasData);
-        if (!targetConfig) {
-            targetConfig = await this._createNewLaunchConfig(mainClasData);
-        }
-        app.activeSessionName = targetConfig.name;
-
-        targetConfig = await resolveDebugConfigurationWithSubstitutedVariables(targetConfig);
-        app.jmxPort = parseJMXPort(targetConfig.vmArgs);
-
-        const cwdUri: vscode.Uri = vscode.Uri.parse(app.path);
-        const launchConfig = Object.assign({}, targetConfig, {
-            noDebug: !debug,
-            cwd: cwdUri.fsPath,
-        });
-        if (profile) {
-            launchConfig.vmArgs = launchConfig.vmArgs + ` -Dspring.profiles.active=${profile}`;
+        const launchStrategy = getWorkspaceLaunchStrategy();
+        if (launchStrategy === "gradle") {
+            await this._runGradleBootApp(app, mainClassData, !!debug, profile);
+            return;
         }
 
-        await vscode.debug.startDebugging(
-            vscode.workspace.getWorkspaceFolder(cwdUri),
-            launchConfig
-        );
+        await this._runJavaBootApp(app, mainClassData, !!debug, profile);
     }
 
     public async runAppWithProfile(app: BootApp, debug?: boolean) {
@@ -92,9 +106,8 @@ export class LocalAppController {
         const detectedProfiles = new Set<string>();
         const foldersToCheck = [...sourceFolders];
 
-        // Add config folders which might contain bootstrap files
         for (const sf of sourceFolders) {
-            const configFolder = path.join(sf, 'config');
+            const configFolder = path.join(sf, "config");
             foldersToCheck.push(configFolder);
         }
 
@@ -106,49 +119,54 @@ export class LocalAppController {
                 for (const f of files) {
                     const res = profilePattern.exec(f[0]);
                     if (res !== null) {
-                        const matchedProfile = res[2]; // Group 2 contains the actual profile name
-                        detectedProfiles.add(matchedProfile);
+                        detectedProfiles.add(res[2]);
                     }
                 }
             } catch (error) {
                 console.log(error);
             }
         }
+
         const selectedProfiles = await vscode.window.showQuickPick(Array.from(detectedProfiles), {
             ignoreFocusOut: true,
             canPickMany: true,
             title: "Select Active Profiles",
-            placeHolder: "will add -Dspring.profiles.active=profile1,profile2... to VMArgs"
+            placeHolder: "will run with spring.profiles.active=profile1,profile2..."
         });
         if (selectedProfiles !== undefined) {
-            const profileArgs = selectedProfiles.join(",");
-            await this.runBootApp(app, debug, profileArgs);
+            await this.runBootApp(app, debug, selectedProfiles.join(","));
         }
     }
 
-
     public onDidStartBootApp(session: vscode.DebugSession): void {
-        // exact match
-        let app: BootApp | undefined = this.manager.getAppList().find((elem: BootApp) => elem.activeSessionName === session.name);
-
-        // workaround if not launched from dashboard, where `activeSessionName` is not set
-        // See https://github.com/microsoft/vscode-spring-boot-dashboard/issues/177
-        if (app === undefined) {
-            app = this.manager.getAppList().find((elem: BootApp) => elem.name === session.configuration.projectName);
+        const role = getSessionRole(session.configuration);
+        if (role === "gradle-attach") {
+            const appPath = session.configuration[SPRING_DASHBOARD_APP_PATH];
+            const app = typeof appPath === "string" ? this.manager.getAppByPath(appPath) : undefined;
+            if (app) {
+                this.manager.bindDebugSession(app, session);
+                app.gradleLaunch = {
+                    ...app.gradleLaunch,
+                    attachSessionName: session.name,
+                    attachSessionId: session.id,
+                    sessionRole: "gradle-attach",
+                };
+                this.manager.fireDidChangeApps(app);
+            }
+            return;
         }
 
+        const app = this._resolveAppForSession(session);
         if (app) {
+            app.launchStrategy = "java";
             this.manager.bindDebugSession(app, session);
             if (isActuatorOnClasspath(session.configuration)) {
-                // actuator enabled: wait live connection to update running state.
                 this._setState(app, AppState.LAUNCHING);
-                sendInfo("", { name: "onDidStartBootApp", withActuator: "true" });
+                sendInfo("", { name: "onDidStartBootApp", withActuator: "true", strategy: "java" });
             } else {
-                // actuator absent: no live connection, set project as 'running' immediately.
                 this._setState(app, AppState.RUNNING);
-                // Guide to enable actuator
                 this.showActuatorGuideIfNecessary(app);
-                sendInfo("", { name: "onDidStartBootApp", withActuator: "false" });
+                sendInfo("", { name: "onDidStartBootApp", withActuator: "false", strategy: "java" });
             }
         }
     }
@@ -156,11 +174,11 @@ export class LocalAppController {
     public async stopBootApps() {
         const appList = this.getAppList();
         if (appList.length === 1 && appList[0].state !== AppState.INACTIVE) {
-            this.stopBootApp(appList[0]);
+            await this.stopBootApp(appList[0]);
         } else {
             const appsToStop = await vscode.window.showQuickPick(
-                appList.filter(app => app.state !== AppState.INACTIVE).map(app => ({ label: app.name, path: app.path })), /** items */
-                { canPickMany: true, placeHolder: "Select apps to stop." } /** options */
+                appList.filter(app => app.state !== AppState.INACTIVE).map(app => ({ label: app.name, path: app.path })),
+                { canPickMany: true, placeHolder: "Select apps to stop." }
             );
             if (appsToStop !== undefined) {
                 const appPaths = appsToStop.map(elem => elem.path);
@@ -170,11 +188,15 @@ export class LocalAppController {
     }
 
     public async stopBootApp(app: BootApp, restart?: boolean): Promise<void> {
-        // TODO: How to send a shutdown signal to the app instead of killing the process directly?
+        const activeLaunchStrategy = app.hasActiveGradleLaunch ? "gradle" : normalizeLaunchStrategy(app.launchStrategy);
+        if (activeLaunchStrategy === "gradle") {
+            await this._stopGradleBootApp(app);
+            return;
+        }
+
         const session: vscode.DebugSession | undefined = this.manager.getSessionByApp(app);
         if (session) {
             if (isRunInTerminal(session) && app.pid) {
-                // kill corresponding process launched in terminal
                 try {
                     process.kill(app.pid);
                 } catch (error) {
@@ -188,10 +210,472 @@ export class LocalAppController {
     }
 
     public onDidStopBootApp(session: vscode.DebugSession): void {
-        const app = this.manager.getAppBySession(session);
+        const role = getSessionRole(session.configuration);
+        if (role === "gradle-attach") {
+            const app = this.manager.unbindDebugSession(session);
+            if (app) {
+                const launch = app.gradleLaunch;
+                if (launch.attachSessionId === session.id || launch.attachSessionName === session.name) {
+                    app.gradleLaunch = {
+                        ...launch,
+                        attachSessionId: undefined,
+                        attachSessionName: undefined,
+                        sessionRole: undefined,
+                    };
+                    this.manager.fireDidChangeApps(app);
+                }
+            }
+            return;
+        }
+
+        const app = this.manager.unbindDebugSession(session);
         if (app) {
             this._setState(app, AppState.INACTIVE);
         }
+    }
+
+    public async openBootApp(app: BootApp): Promise<void> {
+        let openUrl: string | undefined;
+        if (app.contextPath !== undefined && app.port !== undefined) {
+            openUrl = constructOpenUrl(app.contextPath, app.port);
+        } else {
+            openUrl = await this.getOpenUrlFromJMX(app);
+        }
+
+        if (openUrl !== undefined) {
+            const openWithExternalBrowser: boolean = vscode.workspace.getConfiguration("spring.dashboard").get("openWith") === "external";
+            const browserCommand: string = openWithExternalBrowser ? "vscode.open" : "simpleBrowser.api.open";
+
+            let uri = vscode.Uri.parse(openUrl);
+            uri = await vscode.env.asExternalUri(uri);
+            vscode.commands.executeCommand(browserCommand, uri);
+        } else {
+            vscode.window.showErrorMessage("Couldn't determine port app is running on");
+        }
+    }
+
+    private async _resolveMainClass(app: BootApp): Promise<MainClassData | undefined> {
+        const mainClassData = await vscode.window.withProgress(
+            { location: vscode.ProgressLocation.Window, title: `Resolving main classes for ${app.name}...` },
+            async () => {
+                const mainClassList = await app.getMainClasses();
+                if (mainClassList && mainClassList instanceof Array && mainClassList.length > 0) {
+                    return mainClassList.length === 1
+                        ? mainClassList[0]
+                        : await vscode.window.showQuickPick(mainClassList.map(x => Object.assign({ label: x.mainClass }, x)), {
+                            placeHolder: `Specify the main class for ${app.name}`
+                        });
+                }
+                return null;
+            }
+        );
+        if (mainClassData === null) {
+            vscode.window.showWarningMessage("No main class is found.");
+            return undefined;
+        }
+        if (mainClassData === undefined) {
+            return undefined;
+        }
+        return mainClassData;
+    }
+
+    private async _runJavaBootApp(app: BootApp, mainClassData: MainClassData, debug: boolean, profile?: string): Promise<void> {
+        if (app.gradleLaunch.initScriptUri) {
+            await this._clearGradleLaunch(app);
+        } else {
+            app.clearGradleLaunch();
+            app.launchStrategy = "java";
+        }
+
+        let targetConfig = this._getLaunchConfig(mainClassData);
+        if (!targetConfig) {
+            targetConfig = await this._createNewLaunchConfig(mainClassData);
+        }
+        app.activeSessionName = targetConfig.name;
+        app.launchStrategy = "java";
+
+        targetConfig = await resolveDebugConfigurationWithSubstitutedVariables(targetConfig);
+        app.jmxPort = parseJMXPort(targetConfig.vmArgs);
+
+        const cwdUri: vscode.Uri = vscode.Uri.parse(app.path);
+        const launchConfig = Object.assign({}, targetConfig, {
+            noDebug: !debug,
+            cwd: cwdUri.fsPath,
+            [SPRING_DASHBOARD_SESSION_ROLE]: "java-launch",
+            [SPRING_DASHBOARD_APP_PATH]: app.path,
+        });
+        if (profile) {
+            launchConfig.vmArgs = `${launchConfig.vmArgs} -Dspring.profiles.active=${profile}`;
+        }
+
+        await vscode.debug.startDebugging(
+            vscode.workspace.getWorkspaceFolder(cwdUri),
+            launchConfig
+        );
+    }
+
+    private async _runGradleBootApp(app: BootApp, mainClassData: MainClassData, debug: boolean, profile?: string): Promise<void> {
+        if (app.hasActiveGradleLaunch || app.state !== AppState.INACTIVE) {
+            const message = `${app.name} already has an active delegated launch. Stop it before starting another one.`;
+            vscode.window.showErrorMessage(message);
+            sendInfo("", { name: "runBootAppViaGradle", debug: String(debug), result: "failure", reason: "duplicate-launch" });
+            return;
+        }
+
+        const configuredTask = getConfiguredGradleTask(debug);
+        let execution: vscode.TaskExecution | undefined;
+        try {
+            const gradleContext = resolveGradleContext(app.path, configuredTask);
+            const jmxPort = await getPort();
+            const debugPort = debug ? await getPort() : undefined;
+            const initScriptUri = await this._writeGradleInitScript(
+                gradleContext,
+                createGradleInitScript({
+                    task: configuredTask,
+                    projectDir: gradleContext.appFsPath,
+                    appArgs: profile ? [`--spring.profiles.active=${profile}`] : [],
+                    jvmArgs: buildDashboardJvmArgs(mainClassData.projectName, jmxPort),
+                    debugEnabled: debug,
+                    debugPort,
+                })
+            );
+
+            const taskDefinition: GradleTaskDefinition = {
+                type: GRADLE_TASK_TYPE,
+                appPath: app.path,
+                launchId: `${Date.now()}-${Math.random().toString(16).slice(2)}`,
+            };
+            const task = this._createGradleTask(app, gradleContext, configuredTask, initScriptUri, taskDefinition);
+
+            app.launchStrategy = "gradle";
+            app.jmxPort = jmxPort;
+            app.pid = undefined;
+            app.port = undefined;
+            app.contextPath = undefined;
+            app.activeProfiles = undefined;
+            app.activeSessionName = undefined;
+            app.gradleLaunch = {
+                launchStrategy: "gradle",
+                pendingMainClass: mainClassData.mainClass,
+                taskExecution: undefined,
+                taskPath: configuredTask,
+                taskId: taskDefinition.launchId,
+                jmxPort,
+                debugPort,
+                initScriptUri,
+                phase: "launching",
+                sessionRole: debug ? "gradle-attach" : undefined,
+            };
+
+            execution = await vscode.tasks.executeTask(task);
+            app.gradleLaunch = {
+                ...app.gradleLaunch,
+                taskExecution: execution,
+            };
+
+            await this._waitForTaskProcessStart(execution, GRADLE_TASK_START_TIMEOUT_MS);
+            this._setStateAfterGradleLaunch(app);
+
+            if (debug && debugPort !== undefined) {
+                await waitForPort("localhost", debugPort, GRADLE_ATTACH_TIMEOUT_MS);
+                const attachConfig = createAttachDebugConfiguration(
+                    `Spring Boot (Gradle)-${app.name}`,
+                    app.path,
+                    mainClassData.projectName,
+                    debugPort
+                );
+                const started = await vscode.debug.startDebugging(
+                    vscode.workspace.getWorkspaceFolder(vscode.Uri.parse(app.path)),
+                    attachConfig
+                );
+                if (!started) {
+                    throw new Error(`Failed to attach Java debugger to ${app.name}.`);
+                }
+            }
+
+            sendInfo("", { name: "runBootAppViaGradle", debug: String(debug), result: "success" });
+        } catch (error) {
+            sendInfo("", {
+                name: "runBootAppViaGradle",
+                debug: String(debug),
+                result: "failure",
+                reason: error instanceof Error ? error.message : "unknown"
+            });
+            await this._cleanupFailedGradleLaunch(app, execution);
+            vscode.window.showErrorMessage(error instanceof Error ? error.message : `Failed to launch ${app.name} with Gradle.`);
+        }
+    }
+
+    private _createGradleTask(
+        app: BootApp,
+        gradleContext: GradleContext,
+        configuredTask: string,
+        initScriptUri: vscode.Uri,
+        definition: GradleTaskDefinition
+    ): vscode.Task {
+        const args = ["-I", initScriptUri.fsPath, ...gradleContext.args];
+        const task = new vscode.Task(
+            definition,
+            vscode.workspace.getWorkspaceFolder(vscode.Uri.parse(app.path)) ?? vscode.TaskScope.Workspace,
+            `${app.name} (${configuredTask})`,
+            GRADLE_TASK_SOURCE,
+            new vscode.ProcessExecution(gradleContext.executable, args, {
+                cwd: gradleContext.rootDir,
+            })
+        );
+        task.presentationOptions = {
+            reveal: vscode.TaskRevealKind.Always,
+            panel: vscode.TaskPanelKind.Dedicated,
+            clear: false,
+        };
+        return task;
+    }
+
+    private async _writeGradleInitScript(gradleContext: GradleContext, content: string): Promise<vscode.Uri> {
+        const dirUri = getGradleStorageDir();
+        await vscode.workspace.fs.createDirectory(dirUri);
+        const safeName = path.basename(gradleContext.appFsPath).replace(/[^a-zA-Z0-9_.-]/g, "_");
+        const fileUri = vscode.Uri.joinPath(dirUri, `${safeName}-${Date.now()}-${Math.random().toString(16).slice(2)}.gradle`);
+        await vscode.workspace.fs.writeFile(fileUri, Buffer.from(content, "utf8"));
+        return fileUri;
+    }
+
+    private _setStateAfterGradleLaunch(app: BootApp): void {
+        if (app.isActuatorOnClasspath) {
+            app.gradleLaunch = {
+                ...app.gradleLaunch,
+                phase: "launching",
+            };
+            this._setState(app, AppState.LAUNCHING);
+            sendInfo("", { name: "onDidStartBootApp", withActuator: "true", strategy: "gradle" });
+        } else {
+            app.gradleLaunch = {
+                ...app.gradleLaunch,
+                phase: "running",
+            };
+            this._setState(app, AppState.RUNNING);
+            this.showActuatorGuideIfNecessary(app);
+            sendInfo("", { name: "onDidStartBootApp", withActuator: "false", strategy: "gradle" });
+        }
+    }
+
+    private async _stopGradleBootApp(app: BootApp): Promise<void> {
+        const launch = app.gradleLaunch;
+        app.gradleLaunch = {
+            ...launch,
+            phase: "stopping",
+        };
+
+        const session = this.manager.getSessionByApp(app);
+        if (session) {
+            try {
+                await session.customRequest("disconnect", { restart: false });
+            } catch (error) {
+                console.log(error);
+            }
+        }
+
+        if (launch.taskExecution) {
+            try {
+                launch.taskExecution.terminate();
+            } catch (error) {
+                console.log(error);
+            }
+            await this._waitForTaskEnd(launch.taskExecution, GRADLE_STOP_GRACE_PERIOD_MS).catch(error => {
+                console.log(error);
+            });
+        }
+
+        await sleep(GRADLE_STOP_GRACE_PERIOD_MS);
+        if (app.pid && await isAlive(app.pid)) {
+            try {
+                process.kill(app.pid);
+            } catch (error) {
+                console.log(error);
+            }
+        }
+
+        if (!app.pid || !await isAlive(app.pid)) {
+            app.reset();
+            await this._clearGradleLaunch(app);
+        } else {
+            app.gradleLaunch = {
+                ...app.gradleLaunch,
+                taskExecution: undefined,
+            };
+        }
+        sendInfo("", { name: "stopBootAppViaGradle", result: "success" });
+    }
+
+    private async _cleanupFailedGradleLaunch(app: BootApp, execution?: vscode.TaskExecution): Promise<void> {
+        if (execution) {
+            try {
+                execution.terminate();
+            } catch (error) {
+                console.log(error);
+            }
+        }
+        app.reset();
+        await this._clearGradleLaunch(app);
+    }
+
+    private async _clearGradleLaunch(app: BootApp): Promise<void> {
+        const initScriptUri = app.gradleLaunch.initScriptUri;
+        app.clearGradleLaunch();
+        app.launchStrategy = "java";
+        app.jmxPort = undefined;
+        app.activeSessionName = undefined;
+        if (initScriptUri) {
+            try {
+                await vscode.workspace.fs.delete(initScriptUri, { useTrash: false });
+            } catch (error) {
+                console.log(error);
+            }
+        }
+        this.manager.fireDidChangeApps(app);
+    }
+
+    private async _cleanupGradleStorageDir(): Promise<void> {
+        try {
+            await vscode.workspace.fs.delete(getGradleStorageDir(), { recursive: true, useTrash: false });
+        } catch (error) {
+            console.log(error);
+        }
+    }
+
+    private async _waitForTaskProcessStart(execution: vscode.TaskExecution, timeoutMs: number): Promise<void> {
+        await new Promise<void>((resolve, reject) => {
+            const timeout = setTimeout(() => {
+                cleanup();
+                reject(new Error("Gradle task did not start in time."));
+            }, timeoutMs);
+
+            const startDisposable = vscode.tasks.onDidStartTaskProcess((event) => {
+                if (event.execution === execution) {
+                    cleanup();
+                    resolve();
+                }
+            });
+            const endDisposable = vscode.tasks.onDidEndTask((event) => {
+                if (event.execution === execution) {
+                    cleanup();
+                    reject(new Error("Gradle task finished before the process started."));
+                }
+            });
+            const endProcessDisposable = vscode.tasks.onDidEndTaskProcess((event) => {
+                if (event.execution === execution) {
+                    cleanup();
+                    reject(new Error(`Gradle task failed to start${formatExitCode(event.exitCode)}.`));
+                }
+            });
+
+            const cleanup = () => {
+                clearTimeout(timeout);
+                startDisposable.dispose();
+                endDisposable.dispose();
+                endProcessDisposable.dispose();
+            };
+        });
+    }
+
+    private async _waitForTaskEnd(execution: vscode.TaskExecution, timeoutMs: number): Promise<void> {
+        await new Promise<void>((resolve, reject) => {
+            const timeout = setTimeout(() => {
+                cleanup();
+                reject(new Error("Timed out waiting for Gradle task to stop."));
+            }, timeoutMs);
+
+            const endDisposable = vscode.tasks.onDidEndTask((event) => {
+                if (event.execution === execution) {
+                    cleanup();
+                    resolve();
+                }
+            });
+            const endProcessDisposable = vscode.tasks.onDidEndTaskProcess((event) => {
+                if (event.execution === execution) {
+                    cleanup();
+                    resolve();
+                }
+            });
+
+            const cleanup = () => {
+                clearTimeout(timeout);
+                endDisposable.dispose();
+                endProcessDisposable.dispose();
+            };
+        });
+    }
+
+    private async _handleGradleTaskEnd(event: vscode.TaskEndEvent): Promise<void> {
+        const app = this._findAppByTaskExecution(event.execution);
+        if (!app) {
+            return;
+        }
+
+        if (!app.pid && app.gradleLaunch.phase !== "stopping") {
+            app.reset();
+            await this._clearGradleLaunch(app);
+        }
+    }
+
+    private async _handleGradleTaskProcessEnd(event: vscode.TaskProcessEndEvent): Promise<void> {
+        const app = this._findAppByTaskExecution(event.execution);
+        if (!app) {
+            return;
+        }
+
+        const wasStopping = app.gradleLaunch.phase === "stopping";
+        app.gradleLaunch = {
+            ...app.gradleLaunch,
+            taskExecution: undefined,
+        };
+
+        if (app.pid && await isAlive(app.pid)) {
+            if (wasStopping) {
+                this.manager.fireDidChangeApps(app);
+            } else {
+                app.gradleLaunch = {
+                    ...app.gradleLaunch,
+                    phase: "running",
+                };
+            }
+            return;
+        }
+
+        app.reset();
+        await this._clearGradleLaunch(app);
+
+        if (!wasStopping && event.exitCode !== 0) {
+            const message = `${app.name} failed to stay running with Gradle${formatExitCode(event.exitCode)}.`;
+            vscode.window.showErrorMessage(message);
+            sendInfo("", { name: "runBootAppViaGradle", result: "failure", reason: `task-exit${formatExitCode(event.exitCode)}` });
+        }
+    }
+
+    private _findAppByTaskExecution(execution: vscode.TaskExecution): BootApp | undefined {
+        return this.getAppList().find(app => {
+            const definition = execution.task.definition as Partial<GradleTaskDefinition>;
+            return definition.type === GRADLE_TASK_TYPE
+                && definition.appPath === app.path
+                && definition.launchId === app.gradleLaunch.taskId
+                && app.gradleLaunch.taskExecution === execution;
+        });
+    }
+
+    private _resolveAppForSession(session: vscode.DebugSession): BootApp | undefined {
+        const configuredAppPath = session.configuration[SPRING_DASHBOARD_APP_PATH];
+        if (typeof configuredAppPath === "string") {
+            const app = this.manager.getAppByPath(configuredAppPath);
+            if (app) {
+                return app;
+            }
+        }
+
+        let app: BootApp | undefined = this.manager.getAppList().find((elem: BootApp) => elem.activeSessionName === session.name);
+        if (app === undefined) {
+            app = this.manager.getAppList().find((elem: BootApp) => elem.name === session.configuration.projectName);
+        }
+        return app;
     }
 
     private async getOpenUrlFromJMX(app: BootApp) {
@@ -213,8 +697,8 @@ export class LocalAppController {
         );
         const stdout = javaProcess.stdout ? await readAll(javaProcess.stdout) : null;
 
-        let port: number | undefined = undefined;
-        let contextPath: string | undefined = undefined;
+        let port: number | undefined;
+        let contextPath: string | undefined;
 
         READ_JMX_EXTENSION_RESPONSE: {
             if (stdout !== null) {
@@ -227,45 +711,25 @@ export class LocalAppController {
                     break READ_JMX_EXTENSION_RESPONSE;
                 }
 
-                if (jmxExtensionResponse['local.server.port'] !== null && typeof jmxExtensionResponse['local.server.port'] === 'number') {
-                    port = jmxExtensionResponse['local.server.port'];
+                if (jmxExtensionResponse["local.server.port"] !== null && typeof jmxExtensionResponse["local.server.port"] === "number") {
+                    port = jmxExtensionResponse["local.server.port"];
                 }
 
-                if (jmxExtensionResponse['server.servlet.context-path'] !== null) {
-                    contextPath = jmxExtensionResponse['server.servlet.context-path'];
+                if (jmxExtensionResponse["server.servlet.context-path"] !== null) {
+                    contextPath = jmxExtensionResponse["server.servlet.context-path"];
                 }
 
-                if (jmxExtensionResponse['status'] !== null && jmxExtensionResponse['status'] === "failure") {
+                if (jmxExtensionResponse["status"] !== null && jmxExtensionResponse["status"] === "failure") {
                     this._printJavaProcessError(javaProcess);
                 }
             }
         }
 
         if (contextPath === undefined) {
-            contextPath = ""; //if no context path is defined then fallback to root path
+            contextPath = "";
         }
 
         return port ? constructOpenUrl(contextPath, port) : undefined;
-    }
-
-    public async openBootApp(app: BootApp): Promise<void> {
-        let openUrl: string | undefined;
-        if (app.contextPath !== undefined && app.port !== undefined) {
-            openUrl = constructOpenUrl(app.contextPath, app.port);
-        } else {
-            openUrl = await this.getOpenUrlFromJMX(app);
-        }
-
-        if (openUrl !== undefined) {
-            const openWithExternalBrowser: boolean = vscode.workspace.getConfiguration("spring.dashboard").get("openWith") === "external";
-            const browserCommand: string = openWithExternalBrowser ? "vscode.open" : "simpleBrowser.api.open";
-
-            let uri = vscode.Uri.parse(openUrl);
-            uri = await vscode.env.asExternalUri(uri); // Enables Remote envs like Codespaces
-            vscode.commands.executeCommand(browserCommand, uri);
-        } else {
-            vscode.window.showErrorMessage("Couldn't determine port app is running on");
-        }
     }
 
     private async _printJavaProcessError(javaProcess: ChildProcess) {
@@ -325,10 +789,9 @@ export class LocalAppController {
         const lastTimeSeen: number = this.context.globalState.get(key) ?? 0;
         if (new Date(lastTimeSeen) < lastMonth) {
             this.context.globalState.update(key, Date.now());
-            vscode.commands.executeCommand(command, app, true /* asNotification */);
+            vscode.commands.executeCommand(command, app, true);
         }
     }
-
 }
 
 function isRunInTerminal(session: vscode.DebugSession) {
@@ -349,42 +812,27 @@ async function resolveDebugConfigurationWithSubstitutedVariables(debugConfigurat
         debugConfiguration.vmArgs = debugConfiguration.vmArgs.join(" ");
     }
 
-    // Add default vmArgs if not specified
-    if (debugConfiguration.vmArgs.indexOf("-Dcom.sun.management.jmxremote") < 0) {
-        debugConfiguration.vmArgs += " -Dcom.sun.management.jmxremote";
-    }
-    if (debugConfiguration.vmArgs.indexOf("-Dcom.sun.management.jmxremote.port") < 0) {
-        const jmxport = await getPort();
-        debugConfiguration.vmArgs += ` -Dcom.sun.management.jmxremote.port=${jmxport}`;
-    }
-    if (debugConfiguration.vmArgs.indexOf("-Dcom.sun.management.jmxremote.authenticate=") < 0) {
-        debugConfiguration.vmArgs += " -Dcom.sun.management.jmxremote.authenticate=false";
-    }
-    if (debugConfiguration.vmArgs.indexOf("-Dcom.sun.management.jmxremote.ssl=") < 0) {
-        debugConfiguration.vmArgs += " -Dcom.sun.management.jmxremote.ssl=false";
-    }
-    if (debugConfiguration.vmArgs.indexOf("-Dspring.jmx.enabled=") < 0) {
-        debugConfiguration.vmArgs += " -Dspring.jmx.enabled=true";
-    }
-    if (debugConfiguration.vmArgs.indexOf("-Djava.rmi.server.hostname=") < 0) {
-        debugConfiguration.vmArgs += " -Djava.rmi.server.hostname=localhost";
-    }
-    if (debugConfiguration.vmArgs.indexOf("-Dspring.application.admin.enabled=") < 0) {
-        debugConfiguration.vmArgs += " -Dspring.application.admin.enabled=true";
-    }
-    if (debugConfiguration.vmArgs.indexOf("-Dspring.boot.project.name=") < 0) {
-        debugConfiguration.vmArgs += ` -Dspring.boot.project.name=${debugConfiguration.projectName}`;
-    }
-
-
+    const jmxPort = parseJMXPort(debugConfiguration.vmArgs) ?? await getPort();
+    debugConfiguration.vmArgs = ensureDashboardVmArgs(debugConfiguration.vmArgs, debugConfiguration.projectName, jmxPort);
     return debugConfiguration;
 }
 
-function parseJMXPort(vmArgs: string): number | undefined {
+function parseJMXPort(vmArgs: string | undefined): number | undefined {
+    if (!vmArgs) {
+        return undefined;
+    }
     const matched = vmArgs.match(/-Dcom\.sun\.management\.jmxremote\.port=\d+/);
     if (matched) {
         const port = matched[0].substring("-Dcom.sun.management.jmxremote.port=".length);
         return parseInt(port);
     }
     return undefined;
+}
+
+function getSessionRole(configuration: vscode.DebugConfiguration): "java-launch" | "gradle-attach" {
+    return configuration[SPRING_DASHBOARD_SESSION_ROLE] === "gradle-attach" ? "gradle-attach" : "java-launch";
+}
+
+function formatExitCode(exitCode: number | undefined): string {
+    return typeof exitCode === "number" ? ` (exit code ${exitCode})` : "";
 }

--- a/src/LocalAppManager.ts
+++ b/src/LocalAppManager.ts
@@ -75,8 +75,32 @@ export class LocalAppManager {
         this._bindedSessions.set(app.path, session);
     }
 
+    public unbindDebugSession(session: DebugSession): BootApp | undefined {
+        const app = this.getAppBySession(session);
+        if (app) {
+            this._bindedSessions.delete(app.path);
+            if (app.activeSessionName === session.name) {
+                app.activeSessionName = undefined;
+            }
+        }
+        return app;
+    }
+
+    public getAppByPath(location: string): BootApp | undefined {
+        return this._boot_projects.get(location);
+    }
+
     public getAppByMainClass(mainClass: string): BootApp | undefined {
         return this.getAppList().find(app => app.mainClasses?.find((mcd: MainClassData) => mcd.mainClass === mainClass));
+    }
+
+    public getPendingGradleAppByMainClass(mainClass: string): BootApp | undefined {
+        return this.getAppList().find(app => {
+            const launch = app.gradleLaunch;
+            return launch.launchStrategy === "gradle"
+                && (launch.phase === "launching" || launch.phase === "running")
+                && launch.pendingMainClass === mainClass;
+        });
     }
 
     public getAppByPid(pid: number | string): BootApp | undefined {

--- a/src/controllers/LiveDataController.ts
+++ b/src/controllers/LiveDataController.ts
@@ -64,8 +64,18 @@ async function updateProcessInfo(payload: string | LiveProcessPayload) {
     store.data.set(processKey, lp);
 
     if (type === "local") {
-        const runningApp = dashboard.appsProvider.manager.getAppByPid(liveProcess.pid);
+        const runningApp = dashboard.appsProvider.manager.getAppByPid(liveProcess.pid)
+            ?? dashboard.appsProvider.manager.getPendingGradleAppByMainClass(liveProcess.processName);
         if (runningApp) {
+            if (runningApp.pid === undefined) {
+                runningApp.pid = parseInt(liveProcess.pid);
+            }
+            if (runningApp.launchStrategy === "gradle") {
+                runningApp.gradleLaunch = {
+                    ...runningApp.gradleLaunch,
+                    phase: "running",
+                };
+            }
             runningApp.port = parseInt(port);
             runningApp.activeProfiles = activeProfiles;
             runningApp.contextPath = contextPath;

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -43,6 +43,7 @@ export async function initializeExtension(_oprationId: string, context: vscode.E
     dashboard.appsProvider = appsProvider;
 
     const controller: LocalAppController = new LocalAppController(appsProvider.manager, context);
+    context.subscriptions.push(controller);
 
     const appsView = vscode.window.createTreeView('spring.apps', { treeDataProvider: appsProvider, showCollapseAll: false });
     context.subscriptions.push(appsView);

--- a/src/launchUtils.ts
+++ b/src/launchUtils.ts
@@ -1,0 +1,315 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license.
+
+import * as fs from "fs";
+import * as net from "net";
+import * as path from "path";
+import * as vscode from "vscode";
+import { getPathToTempFolder, getPathToWorkspaceStorage } from "./contextUtils";
+import { sanitizeFilePath } from "./symbolUtils";
+
+export type LaunchStrategy = "java" | "gradle";
+export type DebugSessionRole = "java-launch" | "gradle-attach";
+export type GradleLaunchPhase = "idle" | "launching" | "running" | "stopping";
+
+export const SPRING_DASHBOARD_SESSION_ROLE = "springDashboardSessionRole";
+export const SPRING_DASHBOARD_APP_PATH = "springDashboardAppPath";
+
+export interface GradleContext {
+    appFsPath: string;
+    rootDir: string;
+    executable: string;
+    task: string;
+    args: string[];
+    usesWrapper: boolean;
+}
+
+export interface GradleInitScriptOptions {
+    task: string;
+    projectDir: string;
+    appArgs: string[];
+    jvmArgs: string[];
+    debugEnabled: boolean;
+    debugPort?: number;
+}
+
+export function normalizeLaunchStrategy(value: string | undefined): LaunchStrategy {
+    return value === "gradle" ? "gradle" : "java";
+}
+
+export function getWorkspaceLaunchStrategy(): LaunchStrategy {
+    const configured = vscode.workspace.getConfiguration("spring.dashboard").get<string>("launchStrategy");
+    return normalizeLaunchStrategy(configured);
+}
+
+export function getConfiguredGradleTask(debug?: boolean): string {
+    const config = vscode.workspace.getConfiguration("spring.dashboard");
+    const delegatedTask = (config.get<string>("gradle.task") ?? "bootRun").trim();
+    const delegatedDebugTask = (config.get<string>("gradle.debugTask") ?? "").trim();
+    if (debug && delegatedDebugTask.length > 0) {
+        return delegatedDebugTask;
+    }
+    return delegatedTask.length > 0 ? delegatedTask : "bootRun";
+}
+
+export function buildDashboardJvmArgs(projectName: string, jmxPort: number): string[] {
+    return [
+        "-Dcom.sun.management.jmxremote",
+        `-Dcom.sun.management.jmxremote.port=${jmxPort}`,
+        "-Dcom.sun.management.jmxremote.authenticate=false",
+        "-Dcom.sun.management.jmxremote.ssl=false",
+        "-Dspring.jmx.enabled=true",
+        "-Djava.rmi.server.hostname=localhost",
+        "-Dspring.application.admin.enabled=true",
+        `-Dspring.boot.project.name=${projectName}`,
+    ];
+}
+
+export function ensureDashboardVmArgs(vmArgs: string, projectName: string, jmxPort: number): string {
+    let mergedVmArgs = vmArgs;
+    const dashboardArgs = buildDashboardJvmArgs(projectName, jmxPort);
+    const duplicatePatterns: Map<string, RegExp> = new Map([
+        ["-Dcom.sun.management.jmxremote", /-Dcom\.sun\.management\.jmxremote(?!\.)/],
+        ["-Dcom.sun.management.jmxremote.port", /-Dcom\.sun\.management\.jmxremote\.port=\d+/],
+        ["-Dcom.sun.management.jmxremote.authenticate", /-Dcom\.sun\.management\.jmxremote\.authenticate=\S+/],
+        ["-Dcom.sun.management.jmxremote.ssl", /-Dcom\.sun\.management\.jmxremote\.ssl=\S+/],
+        ["-Dspring.jmx.enabled", /-Dspring\.jmx\.enabled=\S+/],
+        ["-Djava.rmi.server.hostname", /-Djava\.rmi\.server\.hostname=\S+/],
+        ["-Dspring.application.admin.enabled", /-Dspring\.application\.admin\.enabled=\S+/],
+        ["-Dspring.boot.project.name", /-Dspring\.boot\.project\.name=\S+/],
+    ]);
+
+    for (const arg of dashboardArgs) {
+        const key = arg.includes("=") ? arg.substring(0, arg.indexOf("=")) : arg;
+        const pattern = duplicatePatterns.get(key);
+        if (pattern && pattern.test(mergedVmArgs)) {
+            continue;
+        }
+        mergedVmArgs += ` ${arg}`;
+    }
+
+    return mergedVmArgs;
+}
+
+export function resolveGradleContext(appPath: string, task: string): GradleContext {
+    const appFsPath = sanitizeFilePath(appPath);
+    const markers = findGradleMarkers(appFsPath);
+    if (!markers.wrapperDir && !markers.settingsDir && !markers.buildDir) {
+        throw new Error(`Project '${appFsPath}' is not recognized as a Gradle project.`);
+    }
+
+    const rootDir = markers.wrapperDir ?? markers.settingsDir ?? markers.buildDir;
+    if (!rootDir) {
+        throw new Error(`Project '${appFsPath}' is not recognized as a Gradle project.`);
+    }
+
+    const executable = markers.wrapperDir ? getWrapperExecutable(markers.wrapperDir) : findGradleExecutableOnPath();
+    if (!executable) {
+        throw new Error("Unable to find Gradle wrapper or 'gradle' executable on PATH.");
+    }
+
+    const args = isQualifiedGradleTask(task) ? [task] : ["-p", appFsPath, task];
+    return {
+        appFsPath,
+        rootDir,
+        executable,
+        task,
+        args,
+        usesWrapper: !!markers.wrapperDir,
+    };
+}
+
+export function createGradleInitScript(options: GradleInitScriptOptions): string {
+    const taskName = options.task.substring(options.task.lastIndexOf(":") + 1);
+    const targetByPath = isQualifiedGradleTask(options.task);
+    const jvmArgs = toGroovyList(options.jvmArgs);
+    const appArgs = toGroovyList(options.appArgs);
+
+    return `import org.gradle.api.GradleException
+import org.gradle.api.tasks.JavaExec
+
+def springDashboardTaskSpec = ${toGroovyString(options.task)}
+def springDashboardTaskName = ${toGroovyString(taskName)}
+def springDashboardProjectDir = new File(${toGroovyString(options.projectDir)})
+def springDashboardTargetByPath = ${targetByPath}
+def springDashboardJvmArgs = ${jvmArgs}
+def springDashboardAppArgs = ${appArgs}
+def springDashboardDebugEnabled = ${options.debugEnabled}
+def springDashboardDebugPort = ${options.debugPort ?? 0}
+def springDashboardMatchedTask = false
+
+def springDashboardMatchesTask = { task ->
+    if (springDashboardTargetByPath) {
+        return task.path == springDashboardTaskSpec
+    }
+    return task.name == springDashboardTaskName && task.project.projectDir == springDashboardProjectDir
+}
+
+gradle.projectsLoaded {
+    gradle.rootProject.allprojects { project ->
+        project.tasks.configureEach { task ->
+            if (!springDashboardMatchesTask(task)) {
+                return
+            }
+            springDashboardMatchedTask = true
+            if (!(task instanceof JavaExec)) {
+                throw new GradleException("Spring Boot Dashboard can only delegate to JavaExec-compatible tasks. Task '" + task.path + "' is " + task.class.name + ".")
+            }
+
+            task.jvmArgs(springDashboardJvmArgs)
+            if (!springDashboardAppArgs.isEmpty()) {
+                task.args(springDashboardAppArgs)
+            }
+
+            if (springDashboardDebugEnabled) {
+                task.debugOptions.enabled = true
+                task.debugOptions.host = "localhost"
+                task.debugOptions.port = springDashboardDebugPort
+                task.debugOptions.server = true
+                task.debugOptions.suspend = true
+            }
+        }
+    }
+
+    gradle.taskGraph.whenReady {
+        if (!springDashboardMatchedTask) {
+            throw new GradleException("Spring Boot Dashboard could not find delegated task '" + springDashboardTaskSpec + "'.")
+        }
+    }
+}
+`;
+}
+
+export function getGradleStorageDir(): vscode.Uri {
+    return getPathToWorkspaceStorage("gradle-delegation") ?? vscode.Uri.file(getPathToTempFolder("gradle-delegation"));
+}
+
+export async function waitForPort(host: string, port: number, timeoutMs: number): Promise<void> {
+    const start = Date.now();
+    while (Date.now() - start < timeoutMs) {
+        try {
+            await canConnect(host, port);
+            return;
+        } catch (error) {
+            void error;
+        }
+        await delay(250);
+    }
+    throw new Error(`Timed out waiting for debugger to listen on ${host}:${port}.`);
+}
+
+export function createAttachDebugConfiguration(name: string, appPath: string, projectName: string, port: number): vscode.DebugConfiguration {
+    return {
+        type: "java",
+        name,
+        request: "attach",
+        hostName: "localhost",
+        port,
+        projectName,
+        [SPRING_DASHBOARD_SESSION_ROLE]: "gradle-attach",
+        [SPRING_DASHBOARD_APP_PATH]: appPath,
+    };
+}
+
+function isQualifiedGradleTask(task: string): boolean {
+    return task.includes(":");
+}
+
+function findGradleMarkers(startDir: string) {
+    let current = path.resolve(startDir);
+    let wrapperDir: string | undefined;
+    let settingsDir: string | undefined;
+    let buildDir: string | undefined;
+
+    while (true) {
+        if (!wrapperDir && hasGradleWrapper(current)) {
+            wrapperDir = current;
+        }
+        if (!settingsDir && hasSettingsBuild(current)) {
+            settingsDir = current;
+        }
+        if (!buildDir && hasModuleBuild(current)) {
+            buildDir = current;
+        }
+
+        const parent = path.dirname(current);
+        if (parent === current) {
+            break;
+        }
+        current = parent;
+    }
+
+    return {
+        wrapperDir,
+        settingsDir,
+        buildDir,
+    };
+}
+
+function hasGradleWrapper(dir: string): boolean {
+    return fs.existsSync(getWrapperExecutable(dir));
+}
+
+function getWrapperExecutable(dir: string): string {
+    return path.join(dir, process.platform === "win32" ? "gradlew.bat" : "gradlew");
+}
+
+function hasSettingsBuild(dir: string): boolean {
+    return fs.existsSync(path.join(dir, "settings.gradle")) || fs.existsSync(path.join(dir, "settings.gradle.kts"));
+}
+
+function hasModuleBuild(dir: string): boolean {
+    return fs.existsSync(path.join(dir, "build.gradle")) || fs.existsSync(path.join(dir, "build.gradle.kts"));
+}
+
+function findGradleExecutableOnPath(): string | undefined {
+    const pathValue = process.env.PATH;
+    if (!pathValue) {
+        return undefined;
+    }
+
+    const executableNames = process.platform === "win32"
+        ? ["gradle.cmd", "gradle.bat", "gradle.exe"]
+        : ["gradle"];
+    const pathEntries = pathValue.split(path.delimiter).filter(entry => entry.length > 0);
+
+    for (const entry of pathEntries) {
+        for (const executableName of executableNames) {
+            const candidate = path.join(entry, executableName);
+            if (fs.existsSync(candidate)) {
+                return candidate;
+            }
+        }
+    }
+    return undefined;
+}
+
+function toGroovyList(values: string[]): string {
+    return `[${values.map(value => toGroovyString(value)).join(", ")}]`;
+}
+
+function toGroovyString(value: string): string {
+    return `'${value.replace(/\\/g, "\\\\").replace(/'/g, "\\'")}'`;
+}
+
+function canConnect(host: string, port: number): Promise<void> {
+    return new Promise<void>((resolve, reject) => {
+        const socket = net.createConnection({ host, port });
+        const onError = (error: Error) => {
+            socket.destroy();
+            reject(error);
+        };
+
+        socket.setTimeout(500);
+        socket.once("connect", () => {
+            socket.end();
+            resolve();
+        });
+        socket.once("timeout", () => onError(new Error("Connection timed out.")));
+        socket.once("error", onError);
+    });
+}
+
+function delay(ms: number): Promise<void> {
+    return new Promise(resolve => setTimeout(resolve, ms));
+}

--- a/test/suite/extension.test.ts
+++ b/test/suite/extension.test.ts
@@ -81,6 +81,8 @@ suite("Extension Test Suite", () => {
         assert.strictEqual(apps.length, 1, "There are 1 app in the app list.");
         const app = apps[0];
 
+        await vscode.workspace.getConfiguration("spring.dashboard").update("launchStrategy", "java");
+
         // Filter to PetClinicApplication to avoid QuickPick when multiple main classes exist
         app.mainClasses = app.mainClasses?.filter(c => c.mainClass.includes("PetClinicApplication"));
         await vscode.commands.executeCommand("spring-boot-dashboard.localapp.run", app);

--- a/test/suite/launchUtils.test.ts
+++ b/test/suite/launchUtils.test.ts
@@ -1,0 +1,111 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license.
+
+import * as assert from "assert";
+import * as fs from "fs";
+import * as os from "os";
+import * as path from "path";
+import * as vscode from "vscode";
+import {
+    buildDashboardJvmArgs,
+    createAttachDebugConfiguration,
+    createGradleInitScript,
+    normalizeLaunchStrategy,
+    resolveGradleContext,
+    SPRING_DASHBOARD_APP_PATH,
+    SPRING_DASHBOARD_SESSION_ROLE,
+} from "../../src/launchUtils";
+
+suite("Launch Utils", () => {
+    let tempDir: string;
+
+    setup(() => {
+        tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "spring-dashboard-gradle-"));
+    });
+
+    teardown(() => {
+        fs.rmSync(tempDir, { recursive: true, force: true });
+    });
+
+    test("resolveGradleContext prefers wrapper and project directory for unqualified tasks", () => {
+        const projectDir = path.join(tempDir, "service");
+        fs.mkdirSync(projectDir, { recursive: true });
+        fs.writeFileSync(path.join(tempDir, "settings.gradle"), "");
+        fs.writeFileSync(path.join(projectDir, "build.gradle"), "");
+        fs.writeFileSync(path.join(tempDir, process.platform === "win32" ? "gradlew.bat" : "gradlew"), "");
+
+        const context = resolveGradleContext(vscode.Uri.file(projectDir).toString(), "bootRun");
+
+        assert.strictEqual(context.rootDir, tempDir);
+        assert.strictEqual(context.appFsPath, projectDir);
+        assert.strictEqual(context.usesWrapper, true);
+        assert.deepStrictEqual(context.args, ["-p", projectDir, "bootRun"]);
+        assert.strictEqual(context.executable, path.join(tempDir, process.platform === "win32" ? "gradlew.bat" : "gradlew"));
+    });
+
+    test("resolveGradleContext keeps fully qualified task paths intact", () => {
+        const projectDir = path.join(tempDir, "service");
+        fs.mkdirSync(projectDir, { recursive: true });
+        fs.writeFileSync(path.join(tempDir, "settings.gradle.kts"), "");
+        fs.writeFileSync(path.join(projectDir, "build.gradle.kts"), "");
+        fs.writeFileSync(path.join(tempDir, process.platform === "win32" ? "gradlew.bat" : "gradlew"), "");
+
+        const context = resolveGradleContext(vscode.Uri.file(projectDir).toString(), ":service:bootRun");
+
+        assert.deepStrictEqual(context.args, [":service:bootRun"]);
+    });
+
+    test("resolveGradleContext falls back to gradle on PATH when there is no wrapper", () => {
+        const projectDir = path.join(tempDir, "service");
+        const binDir = path.join(tempDir, "bin");
+        const gradleExecutable = process.platform === "win32" ? "gradle.bat" : "gradle";
+        const originalPath = process.env.PATH;
+
+        fs.mkdirSync(projectDir, { recursive: true });
+        fs.mkdirSync(binDir, { recursive: true });
+        fs.writeFileSync(path.join(tempDir, "settings.gradle"), "");
+        fs.writeFileSync(path.join(projectDir, "build.gradle"), "");
+        fs.writeFileSync(path.join(binDir, gradleExecutable), "");
+
+        process.env.PATH = `${binDir}${path.delimiter}${originalPath ?? ""}`;
+        try {
+            const context = resolveGradleContext(vscode.Uri.file(projectDir).toString(), "bootRun");
+            assert.strictEqual(context.executable, path.join(binDir, gradleExecutable));
+            assert.strictEqual(context.usesWrapper, false);
+        } finally {
+            process.env.PATH = originalPath;
+        }
+    });
+
+    test("createGradleInitScript injects profiles, JMX/admin flags, and debug options", () => {
+        const script = createGradleInitScript({
+            task: "bootRun",
+            projectDir: "/workspace/service",
+            appArgs: ["--spring.profiles.active=dev,test"],
+            jvmArgs: buildDashboardJvmArgs("demo", 9009),
+            debugEnabled: true,
+            debugPort: 5005,
+        });
+
+        assert.ok(script.includes("--spring.profiles.active=dev,test"));
+        assert.ok(script.includes("-Dcom.sun.management.jmxremote.port=9009"));
+        assert.ok(script.includes("-Dspring.application.admin.enabled=true"));
+        assert.ok(script.includes("task.debugOptions.enabled = true"));
+        assert.ok(script.includes("task.debugOptions.port = springDashboardDebugPort"));
+    });
+
+    test("createAttachDebugConfiguration marks Gradle attach sessions", () => {
+        const config = createAttachDebugConfiguration("attach", "file:///workspace/service", "demo", 5005);
+
+        assert.strictEqual(config.request, "attach");
+        assert.strictEqual(config.hostName, "localhost");
+        assert.strictEqual(config.port, 5005);
+        assert.strictEqual(config[SPRING_DASHBOARD_SESSION_ROLE], "gradle-attach");
+        assert.strictEqual(config[SPRING_DASHBOARD_APP_PATH], "file:///workspace/service");
+    });
+
+    test("normalizeLaunchStrategy defaults to java", () => {
+        assert.strictEqual(normalizeLaunchStrategy(undefined), "java");
+        assert.strictEqual(normalizeLaunchStrategy("gradle"), "gradle");
+    });
+});


### PR DESCRIPTION
Currently, the run always happen with `java` and the compiled files that were produced by the `redhat.java` extension. This is fine in most cases, but it causes some issues when the user has some custom Gradle tasks added to their build.

An example case: a Gradle task, that copies a `yaml` file into build directory. It gets copied into `build`. But this extension runs the output from `bin`, that was compiled using Eclipse from `redhat.java`.

Why not treat Gradle as a first-class citizen?