### PR TITLE
updated to add custom launch configuration main classes

### DIFF
--- a/src/BootApp.ts
+++ b/src/BootApp.ts
@@ -11,13 +11,62 @@ import * as lsp from "vscode-languageclient";
 import * as async from "async";
 import { cpus } from "os";
 
-const searchQueue = async.queue(async (path: string, callback: async.AsyncResultCallback<string[], Error>) => {
-    try {
-        callback(undefined, await vscode.commands.executeCommand('java.execute.workspaceCommand', 'vscode.java.resolveMainClass', path) as string[]);
-    } catch (error) {
-        callback(error);
-    }
-}, Math.max(1, cpus().length / 2));
+const searchQueue = async.queue(
+    async (
+        path: string,
+        callback: async.AsyncResultCallback<MainClassData[], Error>
+    ) => {
+        try {
+            const resolvedMainClasses =
+                (await vscode.commands.executeCommand<MainClassData[]>(
+                    "java.execute.workspaceCommand",
+                    "vscode.java.resolveMainClass",
+                    path
+                )) ?? [];
+
+            // Read existing Java launch configs from .vscode/launch.json (scoped to this path)
+            const launchConfig = vscode.workspace.getConfiguration(
+                "launch",
+                vscode.Uri.file(path)
+            );
+            const rawConfigs =
+                launchConfig.get<vscode.DebugConfiguration[]>("configurations", []) ?? [];
+
+            const fromLaunch: MainClassData[] = rawConfigs
+                .filter(
+                    (c) =>
+                        c.type === "java" &&
+                        c.request === "launch" &&
+                        typeof c.mainClass === "string" &&
+                        c.mainClass.length > 0
+                )
+                .map((c) => ({
+                    // Use provided path as fallback; launch.json does not store source filePath.
+                    filePath: path,
+                    mainClass: c.mainClass as string,
+                    projectName:
+                        typeof c.projectName === "string" ? c.projectName : "",
+                }));
+
+            // Merge without dropping anything from either source
+            const merged: MainClassData[] = [];
+            const seen = new Set<string>();
+
+            for (const mc of [...resolvedMainClasses, ...fromLaunch]) {
+                const key = `${mc.mainClass}|${mc.projectName}`;
+                if (!seen.has(key)) {
+                    seen.add(key);
+                    merged.push(mc);
+                }
+            }
+
+            callback(undefined, merged);
+        } catch (error) {
+            callback(error as Error);
+        }
+    },
+    Math.max(1, Math.floor(cpus().length / 2))
+);
 
 export enum AppState {
     INACTIVE = 'inactive',

--- a/src/BootApp.ts
+++ b/src/BootApp.ts
@@ -29,44 +29,7 @@ const searchQueue = async.queue(
                     request.path
                 )) ?? [];
 
-            // Read existing Java launch configs from .vscode/launch.json (scoped to this path)
-            const projectUri = vscode.Uri.parse(request.path);
-            const launchConfig = vscode.workspace.getConfiguration(
-                "launch",
-                projectUri
-            );
-            const rawConfigs =
-                launchConfig.get<vscode.DebugConfiguration[]>("configurations", []) ?? [];
-
-            const fromLaunch: MainClassData[] = rawConfigs
-                .filter(
-                    (c) =>
-                        c.type === "java" &&
-                        c.request === "launch" &&
-                        (c.projectName === undefined || c.projectName === request.projectName) &&
-                        typeof c.mainClass === "string" &&
-                        c.mainClass.length > 0
-                )
-                .map((c) => ({
-                    // Use provided path as fallback; launch.json does not store source filePath.
-                    filePath: projectUri.fsPath,
-                    mainClass: c.mainClass as string,
-                    projectName: typeof c.projectName === "string" ? c.projectName : undefined,
-                }));
-
-            // Merge without dropping anything from either source
-            const merged: MainClassData[] = [];
-            const seen = new Set<string>();
-
-            for (const mc of [...resolvedMainClasses, ...fromLaunch]) {
-                const key = `${mc.mainClass}|${mc.projectName}`;
-                if (!seen.has(key)) {
-                    seen.add(key);
-                    merged.push(mc);
-                }
-            }
-
-            callback(undefined, merged);
+            callback(undefined, resolvedMainClasses);
         } catch (error) {
             callback(error as Error);
         }

--- a/src/BootApp.ts
+++ b/src/BootApp.ts
@@ -11,9 +11,14 @@ import * as lsp from "vscode-languageclient";
 import * as async from "async";
 import { cpus } from "os";
 
+interface MainClassSearchRequest {
+    path: string;
+    projectName: string;
+}
+
 const searchQueue = async.queue(
     async (
-        path: string,
+        request: MainClassSearchRequest,
         callback: async.AsyncResultCallback<MainClassData[], Error>
     ) => {
         try {
@@ -21,13 +26,14 @@ const searchQueue = async.queue(
                 (await vscode.commands.executeCommand<MainClassData[]>(
                     "java.execute.workspaceCommand",
                     "vscode.java.resolveMainClass",
-                    path
+                    request.path
                 )) ?? [];
 
             // Read existing Java launch configs from .vscode/launch.json (scoped to this path)
+            const projectUri = vscode.Uri.parse(request.path);
             const launchConfig = vscode.workspace.getConfiguration(
                 "launch",
-                vscode.Uri.file(path)
+                projectUri
             );
             const rawConfigs =
                 launchConfig.get<vscode.DebugConfiguration[]>("configurations", []) ?? [];
@@ -37,15 +43,15 @@ const searchQueue = async.queue(
                     (c) =>
                         c.type === "java" &&
                         c.request === "launch" &&
+                        (c.projectName === undefined || c.projectName === request.projectName) &&
                         typeof c.mainClass === "string" &&
                         c.mainClass.length > 0
                 )
                 .map((c) => ({
                     // Use provided path as fallback; launch.json does not store source filePath.
-                    filePath: path,
+                    filePath: projectUri.fsPath,
                     mainClass: c.mainClass as string,
-                    projectName:
-                        typeof c.projectName === "string" ? c.projectName : "",
+                    projectName: typeof c.projectName === "string" ? c.projectName : undefined,
                 }));
 
             // Merge without dropping anything from either source
@@ -226,7 +232,10 @@ export class BootApp {
     public async getMainClasses(): Promise<MainClassData[]> {
         if (this.mainClasses === undefined) {
             // Note: Command `vscode.java.resolveMainClass` is implemented in extension java-debugger
-            const mainClassList = await searchQueue.push(this.path);
+            const mainClassList = await searchQueue.push({
+                path: this.path,
+                projectName: this.name,
+            });
             if (mainClassList && mainClassList instanceof Array) {
                 this.mainClasses = mainClassList;
             } else {

--- a/src/BootApp.ts
+++ b/src/BootApp.ts
@@ -197,7 +197,7 @@ export class BootApp {
     public async getMainClasses(): Promise<MainClassData[]> {
         if (this.mainClasses === undefined) {
             // Note: Command `vscode.java.resolveMainClass` is implemented in extension java-debugger
-            const mainClassList = await searchQueue.push({
+            const mainClassList = await searchQueue.pushAsync({
                 path: this.path,
             });
             if (mainClassList && mainClassList instanceof Array) {

--- a/src/BootApp.ts
+++ b/src/BootApp.ts
@@ -13,7 +13,6 @@ import { cpus } from "os";
 
 interface MainClassSearchRequest {
     path: string;
-    projectName: string;
 }
 
 const searchQueue = async.queue(

--- a/src/BootApp.ts
+++ b/src/BootApp.ts
@@ -199,7 +199,6 @@ export class BootApp {
             // Note: Command `vscode.java.resolveMainClass` is implemented in extension java-debugger
             const mainClassList = await searchQueue.push({
                 path: this.path,
-                projectName: this.name,
             });
             if (mainClassList && mainClassList instanceof Array) {
                 this.mainClasses = mainClassList;

--- a/src/LocalAppController.ts
+++ b/src/LocalAppController.ts
@@ -45,7 +45,7 @@ export class LocalAppController {
         const mainClasData = await vscode.window.withProgress(
             { location: vscode.ProgressLocation.Window, title: `Resolving main classes for ${app.name}...` },
             async () => {
-                const mainClassList = await app.getMainClasses();
+                const mainClassList = await this._getMainClassCandidates(app);
 
                 if (mainClassList && mainClassList instanceof Array && mainClassList.length > 0) {
                     return mainClassList.length === 1 ? mainClassList[0] :
@@ -286,6 +286,43 @@ export class LocalAppController {
         const launchConfigurations: vscode.WorkspaceConfiguration = vscode.workspace.getConfiguration("launch", vscode.Uri.file(mainClasData.filePath));
         const rawConfigs: vscode.DebugConfiguration[] = launchConfigurations.configurations;
         return rawConfigs.find(conf => conf.type === "java" && conf.request === "launch" && conf.mainClass === mainClasData.mainClass && conf.projectName === mainClasData.projectName);
+    }
+
+    private async _getMainClassCandidates(app: BootApp): Promise<MainClassData[]> {
+        const candidates = [
+            ...await app.getMainClasses(),
+            ...this._getLaunchMainClasses(app),
+        ];
+        const seen = new Set<string>();
+
+        return candidates.filter(candidate => {
+            const key = `${candidate.mainClass}|${candidate.projectName}`;
+            if (seen.has(key)) {
+                return false;
+            }
+            seen.add(key);
+            return true;
+        });
+    }
+
+    private _getLaunchMainClasses(app: BootApp): MainClassData[] {
+        const projectUri = vscode.Uri.parse(app.path);
+        const launchConfigurations = vscode.workspace.getConfiguration("launch", projectUri);
+        const rawConfigs: vscode.DebugConfiguration[] = launchConfigurations.configurations;
+
+        return rawConfigs
+            .filter(conf =>
+                conf.type === "java" &&
+                conf.request === "launch" &&
+                (conf.projectName === undefined || conf.projectName === app.name) &&
+                typeof conf.mainClass === "string" &&
+                conf.mainClass.length > 0
+            )
+            .map(conf => ({
+                filePath: projectUri.fsPath,
+                mainClass: conf.mainClass as string,
+                projectName: typeof conf.projectName === "string" ? conf.projectName : undefined,
+            }));
     }
 
     private _constructLaunchConfigName(mainClass: string, projectName?: string) {

--- a/src/LocalAppController.ts
+++ b/src/LocalAppController.ts
@@ -8,7 +8,7 @@ import * as vscode from "vscode";
 import { AppState, BootApp } from "./BootApp";
 import { LocalAppManager } from "./LocalAppManager";
 import { MainClassData } from "./types/jdtls";
-import { constructOpenUrl, isActuatorJarFile, readAll } from "./utils";
+import { constructOpenUrl, isActuatorJarFile, isConcreteJavaLaunchConfiguration, readAll } from "./utils";
 
 import getPort = require("get-port");
 import { sendInfo } from "vscode-extension-telemetry-wrapper";
@@ -307,21 +307,29 @@ export class LocalAppController {
 
     private _getLaunchMainClasses(app: BootApp): MainClassData[] {
         const projectUri = vscode.Uri.parse(app.path);
-        const launchConfigurations = vscode.workspace.getConfiguration("launch", projectUri);
-        const rawConfigs: vscode.DebugConfiguration[] = launchConfigurations.configurations;
+        const workspaceFolder = vscode.workspace.getWorkspaceFolder(projectUri);
+        const appsInFolder = workspaceFolder === undefined ? [] :
+            this.manager.getAppList().filter(candidate =>
+                vscode.workspace.getWorkspaceFolder(
+                    vscode.Uri.parse(candidate.path)
+                )?.uri.toString() === workspaceFolder.uri.toString()
+            );
+        const includeUnscoped = appsInFolder.length === 1 && appsInFolder[0] === app;
 
-        return rawConfigs
-            .filter(conf =>
-                conf.type === "java" &&
-                conf.request === "launch" &&
-                (conf.projectName === undefined || conf.projectName === app.name) &&
-                typeof conf.mainClass === "string" &&
-                conf.mainClass.length > 0
+        const configurations = vscode.workspace
+            .getConfiguration("launch", projectUri)
+            .get<vscode.DebugConfiguration[]>("configurations", []);
+
+        return configurations
+            .filter(config =>
+                isConcreteJavaLaunchConfiguration(config) &&
+                (config.projectName === app.name ||
+                    (config.projectName === undefined && includeUnscoped))
             )
-            .map(conf => ({
+            .map(config => ({
                 filePath: projectUri.fsPath,
-                mainClass: conf.mainClass as string,
-                projectName: typeof conf.projectName === "string" ? conf.projectName : undefined,
+                mainClass: config.mainClass,
+                projectName: config.projectName,
             }));
     }
 

--- a/src/LocalAppController.ts
+++ b/src/LocalAppController.ts
@@ -288,7 +288,7 @@ export class LocalAppController {
         return rawConfigs.find(conf => conf.type === "java" && conf.request === "launch" && conf.mainClass === mainClasData.mainClass && conf.projectName === mainClasData.projectName);
     }
 
-    private _constructLaunchConfigName(mainClass: string, projectName: string) {
+    private _constructLaunchConfigName(mainClass: string, projectName?: string) {
         const prefix = "Spring Boot-";
         let name = prefix + mainClass.substr(mainClass.lastIndexOf(".") + 1);
         if (projectName !== undefined) {

--- a/src/LocalAppController.ts
+++ b/src/LocalAppController.ts
@@ -69,7 +69,11 @@ export class LocalAppController {
         }
         app.activeSessionName = targetConfig.name;
 
-        targetConfig = await resolveDebugConfigurationWithSubstitutedVariables(targetConfig);
+        // Scope the runtime configuration without changing the launch.json entry.
+        targetConfig = await resolveDebugConfigurationWithSubstitutedVariables({
+            ...targetConfig,
+            projectName: targetConfig.projectName ?? app.name,
+        });
         app.jmxPort = parseJMXPort(targetConfig.vmArgs);
 
         const cwdUri: vscode.Uri = vscode.Uri.parse(app.path);
@@ -336,7 +340,7 @@ export class LocalAppController {
 
     private _constructLaunchConfigName(mainClass: string, projectName?: string) {
         const prefix = "Spring Boot-";
-        let name = prefix + mainClass.substr(mainClass.lastIndexOf(".") + 1);
+        let name = prefix + mainClass.substring(mainClass.lastIndexOf(".") + 1);
         if (projectName !== undefined) {
             name += `<${projectName}>`;
         }

--- a/src/LocalAppController.ts
+++ b/src/LocalAppController.ts
@@ -294,14 +294,16 @@ export class LocalAppController {
     }
 
     private async _getMainClassCandidates(app: BootApp): Promise<MainClassData[]> {
+        const mainClasses = await app.getLaunchableMainClasses();
+        // Prefer launch.json entries so deduplication preserves their configuration identity.
         const candidates = [
-            ...await app.getLaunchableMainClasses(),
             ...this._getLaunchMainClasses(app),
+            ...mainClasses,
         ];
         const seen = new Set<string>();
 
         return candidates.filter(candidate => {
-            const key = `${candidate.mainClass}|${candidate.projectName}`;
+            const key = `${candidate.mainClass}|${candidate.projectName ?? app.name}`;
             if (seen.has(key)) {
                 return false;
             }

--- a/src/types/jdtls.d.ts
+++ b/src/types/jdtls.d.ts
@@ -1,7 +1,7 @@
 export interface MainClassData {
     filePath: string;
     mainClass: string;
-    projectName: string;
+    projectName?: string;
 }
 
 export interface ClassPathData {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -6,6 +6,16 @@ import { Readable } from "stream";
 import * as vscode from "vscode";
 import pidtree = require("pidtree");
 
+export function isConcreteJavaLaunchConfiguration(
+    config: vscode.DebugConfiguration
+): config is vscode.DebugConfiguration & { mainClass: string } {
+    return config.type === "java" &&
+        config.request === "launch" &&
+        typeof config.mainClass === "string" &&
+        config.mainClass.trim().length > 0 &&
+        !/\$\{[^}]+\}/.test(config.mainClass);
+}
+
 export function readAll(input: Readable): Promise<string> {
     let buffer = "";
     return new Promise<string>((resolve, reject) => {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -6,16 +6,6 @@ import { Readable } from "stream";
 import * as vscode from "vscode";
 import pidtree = require("pidtree");
 
-export function isConcreteJavaLaunchConfiguration(
-    config: vscode.DebugConfiguration
-): config is vscode.DebugConfiguration & { mainClass: string } {
-    return config.type === "java" &&
-        config.request === "launch" &&
-        typeof config.mainClass === "string" &&
-        config.mainClass.trim().length > 0 &&
-        !/\$\{[^}]+\}/.test(config.mainClass);
-}
-
 export function readAll(input: Readable): Promise<string> {
     let buffer = "";
     return new Promise<string>((resolve, reject) => {
@@ -48,6 +38,16 @@ export async function sleep(ms: number) {
             resolve();
         }, ms);
     });
+}
+
+export function isConcreteJavaLaunchConfiguration(
+    config: vscode.DebugConfiguration
+): config is vscode.DebugConfiguration & { mainClass: string } {
+    return config.type === "java" &&
+        config.request === "launch" &&
+        typeof config.mainClass === "string" &&
+        config.mainClass.trim().length > 0 &&
+        !/\$\{[^}]+\}/.test(config.mainClass);
 }
 
 export function isActuatorJarFile(f: string): boolean {

--- a/test/suite/launchConfigurations.test.ts
+++ b/test/suite/launchConfigurations.test.ts
@@ -71,7 +71,12 @@ suite("Launch configuration main classes", () => {
             mainClass: "example.TestApplication",
             projectName: app.name
         };
-        app.mainClasses = [productionMain, testMain];
+        const unconfiguredMain = {
+            filePath: path.join(projectPath, "src", "main", "OtherApplication.java"),
+            mainClass: "example.OtherApplication",
+            projectName: app.name
+        };
+        app.mainClasses = [productionMain, unconfiguredMain, testMain];
         app.classpath = {
             entries: ["main", "test"].map(source => ({
                 kind: "source",
@@ -92,10 +97,16 @@ suite("Launch configuration main classes", () => {
         const candidates = await controller["_getMainClassCandidates"](app);
         assert.deepStrictEqual(candidates.map(candidate => candidate.mainClass), [
             "example.Application",
-            "library.Application"
+            "library.Application",
+            "example.OtherApplication"
         ]);
-        assert.strictEqual(candidates[0], productionMain);
-        assert.deepStrictEqual(app.mainClasses, [productionMain, testMain]);
+        assert.deepStrictEqual(candidates[0], {
+            filePath: projectPath,
+            mainClass: productionMain.mainClass,
+            projectName: app.name
+        });
+        assert.strictEqual(candidates[2], unconfiguredMain);
+        assert.deepStrictEqual(app.mainClasses, [productionMain, unconfiguredMain, testMain]);
     });
 
     test("Preserves URI paths and unscoped configuration options", async () => {
@@ -162,8 +173,13 @@ suite("Launch configuration main classes", () => {
         assert.strictEqual(app.mainClasses, cachedMainClasses);
     });
 
-    for (const scoped of [false, true]) {
-        test(`Keeps project identity and options when launching a ${scoped ? "scoped" : "unscoped"} configuration`, async () => {
+    for (const { scoped, discovered } of [
+        { scoped: false, discovered: false },
+        { scoped: false, discovered: true },
+        { scoped: true, discovered: false },
+        { scoped: true, discovered: true }
+    ]) {
+        test(`Preserves ${scoped ? "scoped" : "unscoped"} launch options ${discovered ? "with" : "without"} a discovered main class`, async () => {
             const config = {
                 ...configuration("library.Application", scoped ? app.name : undefined),
                 classPaths: ["lib/application.jar"],
@@ -171,7 +187,16 @@ suite("Launch configuration main classes", () => {
                 args: "--custom",
                 env: { CUSTOM: "true" }
             };
+            app.mainClasses = discovered ? [{
+                filePath: path.join(vscode.Uri.parse(app.path).fsPath, "Application.java"),
+                mainClass: "library.Application",
+                projectName: app.name
+            }] : [];
+            const cachedMainClasses = app.mainClasses;
             await launch.update("configurations", [config], vscode.ConfigurationTarget.WorkspaceFolder);
+            const candidates = await controller["_getMainClassCandidates"](app);
+            assert.strictEqual(candidates.length, 1);
+            assert.strictEqual(candidates[0].projectName, scoped ? app.name : undefined);
             const startedConfigurations: vscode.DebugConfiguration[] = [];
             const originalStartDebugging = vscode.debug.startDebugging;
             try {
@@ -197,6 +222,7 @@ suite("Launch configuration main classes", () => {
             assert.deepStrictEqual(started.env, config.env);
             assert.strictEqual(started.cwd, vscode.Uri.parse(app.path).fsPath);
             assert.strictEqual(started.noDebug, false);
+            assert.strictEqual(app.mainClasses, cachedMainClasses);
             assert.deepStrictEqual(
                 vscode.workspace.getConfiguration("launch", vscode.Uri.parse(app.path)).get("configurations"),
                 [config]

--- a/test/suite/launchConfigurations.test.ts
+++ b/test/suite/launchConfigurations.test.ts
@@ -162,6 +162,57 @@ suite("Launch configuration main classes", () => {
         assert.strictEqual(app.mainClasses, cachedMainClasses);
     });
 
+    for (const scoped of [false, true]) {
+        test(`Keeps project identity and options when launching a ${scoped ? "scoped" : "unscoped"} configuration`, async () => {
+            const config = {
+                ...configuration("library.Application", scoped ? app.name : undefined),
+                classPaths: ["lib/application.jar"],
+                vmArgs: "-Dcustom=true",
+                args: "--custom",
+                env: { CUSTOM: "true" }
+            };
+            await launch.update("configurations", [config], vscode.ConfigurationTarget.WorkspaceFolder);
+            const startedConfigurations: vscode.DebugConfiguration[] = [];
+            const originalStartDebugging = vscode.debug.startDebugging;
+            try {
+                vscode.debug.startDebugging = async (_folder, debugConfiguration) => {
+                    assert.ok(typeof debugConfiguration !== "string");
+                    startedConfigurations.push(debugConfiguration);
+                    return true;
+                };
+
+                await controller.runBootApp(app, true);
+            } finally {
+                vscode.debug.startDebugging = originalStartDebugging;
+            }
+
+            assert.strictEqual(startedConfigurations.length, 1);
+            const started = startedConfigurations[0];
+            assert.strictEqual(started.projectName, app.name);
+            assert.ok(started.vmArgs.includes(`-Dspring.boot.project.name=${app.name}`));
+            assert.ok(started.vmArgs.includes("-Dcustom=true"));
+            assert.strictEqual(started.name, config.name);
+            assert.deepStrictEqual(started.classPaths, config.classPaths);
+            assert.strictEqual(started.args, config.args);
+            assert.deepStrictEqual(started.env, config.env);
+            assert.strictEqual(started.cwd, vscode.Uri.parse(app.path).fsPath);
+            assert.strictEqual(started.noDebug, false);
+            assert.deepStrictEqual(
+                vscode.workspace.getConfiguration("launch", vscode.Uri.parse(app.path)).get("configurations"),
+                [config]
+            );
+        });
+    }
+
+    test("Builds launch names for qualified and unqualified main classes", () => {
+        assert.strictEqual(controller["_constructLaunchConfigName"]("example.Application"), "Spring Boot-Application");
+        assert.strictEqual(controller["_constructLaunchConfigName"]("Application"), "Spring Boot-Application");
+        assert.strictEqual(
+            controller["_constructLaunchConfigName"]("example.Application", app.name),
+            "Spring Boot-Application<example>"
+        );
+    });
+
     test("Ignores variable-based, empty, and non-Java launchers", async () => {
         const invalidConfigurations = [
             configuration("${file}"),


### PR DESCRIPTION
Updated the main class finding logic so that in the case of situations where custom main classes that are pulled from other imports can be set in the launch configuration json file. Its bad design i know to have your main class pulled from another component but this is just some legacy code that needs to be maintained. This fixes our issue without affecting current functionality.