### PR TITLE
Ignore @SpringBootApplication classes in test source folders

### DIFF
--- a/src/BootApp.ts
+++ b/src/BootApp.ts
@@ -5,7 +5,7 @@ import * as vscode from "vscode";
 import { dashboard } from "./global";
 import { requestWorkspaceSymbols } from "./models/stsApi";
 import { ClassPathData, MainClassData } from "./types/jdtls";
-import { isActuatorJarFile, isAlive } from "./utils";
+import { excludeTestMainClasses, isActuatorJarFile, isAlive } from "./utils";
 import { BootAppItem } from "./views/items/BootAppItem";
 import * as lsp from "vscode-languageclient";
 import * as async from "async";
@@ -185,6 +185,19 @@ export class BootApp {
             }
         }
         return this.mainClasses;
+    }
+
+    /**
+     * The main classes offered to the user when running/debugging this app, i.e. all
+     * resolved main classes except the ones located in test source folders.
+     *
+     * Falls back to the full list when every main class is in a test source folder, so
+     * that a project whose only main class lives there stays launchable.
+     */
+    public async getLaunchableMainClasses(): Promise<MainClassData[]> {
+        const mainClasses = await this.getMainClasses();
+        const launchable = excludeTestMainClasses(mainClasses, this.classpath);
+        return launchable.length > 0 ? launchable : mainClasses;
     }
 
     /**

--- a/src/BootApp.ts
+++ b/src/BootApp.ts
@@ -199,7 +199,7 @@ export class BootApp {
      */
     public async getLaunchableMainClasses(): Promise<MainClassData[]> {
         const mainClasses = await this.getMainClasses();
-        const launchable = excludeTestMainClasses(mainClasses, this.classpath);
+        const launchable = await excludeTestMainClasses(mainClasses, this.classpath);
         return launchable.length > 0 ? launchable : mainClasses;
     }
 

--- a/src/LocalAppController.ts
+++ b/src/LocalAppController.ts
@@ -62,9 +62,10 @@ export class LocalAppController {
             return;
         }
 
-        let targetConfig = this._getLaunchConfig(mainClasData);
+        const configResource = mainClasData.filePath ? vscode.Uri.file(mainClasData.filePath) : vscode.Uri.parse(app.path);
+        let targetConfig = this._getLaunchConfig(mainClasData, configResource);
         if (!targetConfig) {
-            targetConfig = await this._createNewLaunchConfig(mainClasData);
+            targetConfig = await this._createNewLaunchConfig(mainClasData, configResource);
         }
         app.activeSessionName = targetConfig.name;
 
@@ -282,8 +283,8 @@ export class LocalAppController {
         dashboard.mappingsProvider.refresh(app);
     }
 
-    private _getLaunchConfig(mainClasData: MainClassData) {
-        const launchConfigurations: vscode.WorkspaceConfiguration = vscode.workspace.getConfiguration("launch", vscode.Uri.file(mainClasData.filePath));
+    private _getLaunchConfig(mainClasData: MainClassData, configResource: vscode.Uri) {
+        const launchConfigurations: vscode.WorkspaceConfiguration = vscode.workspace.getConfiguration("launch", configResource);
         const rawConfigs: vscode.DebugConfiguration[] = launchConfigurations.configurations;
         return rawConfigs.find(conf => conf.type === "java" && conf.request === "launch" && conf.mainClass === mainClasData.mainClass && conf.projectName === mainClasData.projectName);
     }
@@ -297,7 +298,7 @@ export class LocalAppController {
         return name;
     }
 
-    private async _createNewLaunchConfig(mainClasData: MainClassData): Promise<vscode.DebugConfiguration> {
+    private async _createNewLaunchConfig(mainClasData: MainClassData, configResource: vscode.Uri): Promise<vscode.DebugConfiguration> {
         const newConfig = {
             type: "java",
             name: this._constructLaunchConfigName(mainClasData.mainClass, mainClasData.projectName),
@@ -308,7 +309,7 @@ export class LocalAppController {
             args: "",
             envFile: "${workspaceFolder}/.env"
         };
-        const launchConfigurations: vscode.WorkspaceConfiguration = vscode.workspace.getConfiguration("launch", vscode.Uri.file(mainClasData.filePath));
+        const launchConfigurations: vscode.WorkspaceConfiguration = vscode.workspace.getConfiguration("launch", configResource);
         const configs: vscode.DebugConfiguration[] = launchConfigurations.configurations;
         configs.push(newConfig);
         await launchConfigurations.update("configurations", configs, vscode.ConfigurationTarget.WorkspaceFolder);

--- a/src/LocalAppController.ts
+++ b/src/LocalAppController.ts
@@ -45,7 +45,7 @@ export class LocalAppController {
         const mainClasData = await vscode.window.withProgress(
             { location: vscode.ProgressLocation.Window, title: `Resolving main classes for ${app.name}...` },
             async () => {
-                const mainClassList = await app.getMainClasses();
+                const mainClassList = await app.getLaunchableMainClasses();
 
                 if (mainClassList && mainClassList instanceof Array && mainClassList.length > 0) {
                     return mainClassList.length === 1 ? mainClassList[0] :

--- a/src/types/jdtls.d.ts
+++ b/src/types/jdtls.d.ts
@@ -15,4 +15,5 @@ interface CPE {
     sourceContainerUrl: string;
     javadocContainerUrl: string;
     isSystem: boolean;
+    isTest: boolean;
 }

--- a/src/types/jdtls.d.ts
+++ b/src/types/jdtls.d.ts
@@ -1,5 +1,5 @@
 export interface MainClassData {
-    filePath: string;
+    filePath?: string;
     mainClass: string;
     projectName: string;
 }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -4,6 +4,7 @@
 import * as path from "path";
 import { Readable } from "stream";
 import * as vscode from "vscode";
+import { ClassPathData, MainClassData } from "./types/jdtls";
 import pidtree = require("pidtree");
 
 export function readAll(input: Readable): Promise<string> {
@@ -46,6 +47,39 @@ export function isActuatorJarFile(f: string): boolean {
         return true;
     }
     return false;
+}
+
+/**
+ * Whether `filePath` is located inside `folder`. Both are expected to be
+ * absolute file system paths.
+ */
+function isInFolder(filePath: string, folder: string): boolean {
+    const relative = path.relative(folder, filePath);
+    // An empty result means both point at the same location, ".." means filePath
+    // is outside, and an absolute result means they are on different drives.
+    return !!relative && !relative.startsWith("..") && !path.isAbsolute(relative);
+}
+
+/**
+ * Drops the main classes that live in a test source folder of the project.
+ *
+ * `vscode.java.resolveMainClass` searches all source folders, so a
+ * `@SpringBootApplication` class copied into `src/test/java` (a common pattern for
+ * integration tests) shows up as an additional candidate to launch. Those classes
+ * are not what users want to run from the dashboard, and offering them turns a
+ * one-click "run" into a quick pick with irrelevant choices.
+ *
+ * See https://github.com/microsoft/vscode-spring-boot-dashboard/issues/420
+ */
+export function excludeTestMainClasses(mainClasses: MainClassData[], classpath: ClassPathData): MainClassData[] {
+    const testSourceFolders = (classpath?.entries ?? [])
+        .filter(cpe => cpe.kind === "source" && cpe.isTest)
+        .map(cpe => cpe.path);
+    if (testSourceFolders.length === 0) {
+        return mainClasses;
+    }
+    // Keep entries without a file path: they cannot be located, so they cannot be ruled out.
+    return mainClasses.filter(mc => !mc.filePath || !testSourceFolders.some(folder => isInFolder(mc.filePath, folder)));
 }
 
 /**

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -86,6 +86,16 @@ function isInFolder(filePath: string, folder: string): boolean {
         && !path.isAbsolute(relative);
 }
 
+type TestFileClassifier = (filePath: string) => Promise<boolean>;
+
+async function isJavaTestFile(filePath: string): Promise<boolean> {
+    return await vscode.commands.executeCommand<boolean>(
+        "java.execute.workspaceCommand",
+        "java.project.isTestFile",
+        vscode.Uri.file(filePath).toString()
+    ) === true;
+}
+
 /**
  * Drops the main classes that live in a test source folder of the project.
  *
@@ -97,18 +107,39 @@ function isInFolder(filePath: string, folder: string): boolean {
  *
  * See https://github.com/microsoft/vscode-spring-boot-dashboard/issues/420
  */
-export function excludeTestMainClasses(mainClasses: MainClassData[], classpath: ClassPathData): MainClassData[] {
-    const testSourceFolders = (classpath?.entries ?? [])
-        .filter(cpe => cpe.kind === "source" && cpe.isTest)
-        .map(cpe => cpe.path);
+export async function excludeTestMainClasses(
+    mainClasses: MainClassData[],
+    classpath: ClassPathData,
+    classifyTestFile: TestFileClassifier = isJavaTestFile
+): Promise<MainClassData[]> {
+    const sourceFolders = (classpath?.entries ?? [])
+        .filter(cpe => cpe.kind === "source");
+    const testSourceFolders = sourceFolders.filter(cpe => cpe.isTest);
     if (testSourceFolders.length === 0) {
         return mainClasses;
     }
-    // Keep entries without a file path: they cannot be located, so they cannot be ruled out.
-    return mainClasses.filter(mc => {
+
+    const testMainClasses = await Promise.all(mainClasses.map(async mc => {
         const filePath = mc.filePath;
-        return !filePath || !testSourceFolders.some(folder => isInFolder(filePath, folder));
-    });
+        if (!filePath) {
+            return false;
+        }
+        if (testSourceFolders.some(cpe => isInFolder(filePath, cpe.path))) {
+            return true;
+        }
+        if (sourceFolders.some(cpe => isInFolder(filePath, cpe.path))) {
+            return false;
+        }
+
+        // Linked source folders can have different logical and physical paths.
+        try {
+            return await classifyTestFile(filePath);
+        } catch {
+            return false;
+        }
+    }));
+
+    return mainClasses.filter((_, index) => !testMainClasses[index]);
 }
 
 /**

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -77,9 +77,13 @@ export function isActuatorJarFile(f: string): boolean {
  */
 function isInFolder(filePath: string, folder: string): boolean {
     const relative = path.relative(folder, filePath);
-    // An empty result means both point at the same location, ".." means filePath
-    // is outside, and an absolute result means they are on different drives.
-    return !!relative && !relative.startsWith("..") && !path.isAbsolute(relative);
+    // An empty result means both point at the same location, a leading ".."
+    // segment means filePath is outside, and an absolute result means they are
+    // on different drives.
+    return !!relative
+        && relative !== ".."
+        && !relative.startsWith(`..${path.sep}`)
+        && !path.isAbsolute(relative);
 }
 
 /**

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -72,8 +72,8 @@ export function isActuatorJarFile(f: string): boolean {
 }
 
 /**
- * Whether `filePath` is located inside `folder`. Both are expected to be
- * absolute file system paths.
+ * Whether `filePath` is located strictly inside `folder` (excluding the folder
+ * itself). Both are expected to be absolute file system paths.
  */
 function isInFolder(filePath: string, folder: string): boolean {
     const relative = path.relative(folder, filePath);
@@ -101,7 +101,10 @@ export function excludeTestMainClasses(mainClasses: MainClassData[], classpath: 
         return mainClasses;
     }
     // Keep entries without a file path: they cannot be located, so they cannot be ruled out.
-    return mainClasses.filter(mc => !mc.filePath || !testSourceFolders.some(folder => isInFolder(mc.filePath, folder)));
+    return mainClasses.filter(mc => {
+        const filePath = mc.filePath;
+        return !filePath || !testSourceFolders.some(folder => isInFolder(filePath, folder));
+    });
 }
 
 /**

--- a/test/suite/extension.test.ts
+++ b/test/suite/extension.test.ts
@@ -92,7 +92,7 @@ suite("Extension Test Suite", () => {
         // petclinic declares a main method in PetClinicApplication plus three more in
         // src/test/java (MysqlTestApplication, PetClinicIntegrationTests, PostgresIntegrationTests).
         const allMainClasses = await app.getMainClasses();
-        const testMainClasses = allMainClasses.filter(c => c.filePath.includes(path.join("src", "test", "java")));
+        const testMainClasses = allMainClasses.filter(c => c.filePath?.includes(path.join("src", "test", "java")));
         assert.ok(testMainClasses.length > 0, `There should be main classes in test source folders, but got ${JSON.stringify(allMainClasses)}.`);
 
         // Only the one in src/main/java is a launch candidate. https://github.com/microsoft/vscode-spring-boot-dashboard/issues/420

--- a/test/suite/extension.test.ts
+++ b/test/suite/extension.test.ts
@@ -7,7 +7,7 @@ import { AppState } from "../../src/BootApp";
 import { initSymbols } from "../../src/controllers/SymbolsController";
 import { dashboard } from "../../src/global";
 import { StaticEndpoint } from "../../src/models/StaticSymbolTypes";
-import { isAlive } from "../../src/utils";
+import { excludeTestMainClasses, isAlive } from "../../src/utils";
 import { Bean } from "../../src/views/beans";
 import { Endpoint } from "../../src/views/mappings";
 import { setupTestEnv, sleep } from "../utils";
@@ -25,6 +25,38 @@ suite("Extension Test Suite", () => {
     test("Keeps process state when detection fails", async () => {
         const error = new Error("Process detection unavailable");
         assert.strictEqual(await isAlive(process.pid, async () => { throw error; }), undefined);
+    });
+
+    test("Treats two-dot-prefixed directories as source-folder children", () => {
+        const testSourceFolder = path.resolve("workspace", "src", "test");
+        const mainClasses = [
+            {
+                mainClass: "example.TestApplication",
+                projectName: "example",
+                filePath: path.join(testSourceFolder, "..generated", "TestApplication.java")
+            },
+            {
+                mainClass: "example.OutsideApplication",
+                projectName: "example",
+                filePath: path.resolve(testSourceFolder, "..", "outside", "OutsideApplication.java")
+            }
+        ];
+        const classpath = {
+            entries: [{
+                kind: "source",
+                path: testSourceFolder,
+                outputFolder: "",
+                sourceContainerUrl: "",
+                javadocContainerUrl: "",
+                isSystem: false,
+                isTest: true
+            }]
+        };
+
+        assert.deepStrictEqual(
+            excludeTestMainClasses(mainClasses, classpath).map(c => c.mainClass),
+            ["example.OutsideApplication"]
+        );
     });
 
     test("Can view static beans and mappings", async () => {
@@ -92,8 +124,9 @@ suite("Extension Test Suite", () => {
         // petclinic declares a main method in PetClinicApplication plus three more in
         // src/test/java (MysqlTestApplication, PetClinicIntegrationTests, PostgresIntegrationTests).
         const allMainClasses = await app.getMainClasses();
-        const testMainClasses = allMainClasses.filter(c => c.filePath?.includes(path.join("src", "test", "java")));
-        assert.ok(testMainClasses.length > 0, `There should be main classes in test source folders, but got ${JSON.stringify(allMainClasses)}.`);
+        const testClassNames = ["MysqlTestApplication", "PetClinicIntegrationTests", "PostgresIntegrationTests"];
+        const missingTestClasses = testClassNames.filter(name => !allMainClasses.some(c => c.mainClass.endsWith(`.${name}`)));
+        assert.deepStrictEqual(missingTestClasses, [], `Expected all test main classes, but got ${JSON.stringify(allMainClasses)}.`);
 
         // Only the one in src/main/java is a launch candidate. https://github.com/microsoft/vscode-spring-boot-dashboard/issues/420
         const launchable = await app.getLaunchableMainClasses();

--- a/test/suite/extension.test.ts
+++ b/test/suite/extension.test.ts
@@ -137,6 +137,25 @@ suite("Extension Test Suite", () => {
         );
     }).timeout(300 * 1000 /** ms */);
 
+    test("Should keep projects with only test main classes launchable", async () => {
+        const app = dashboard.appsProvider.manager.getAppList()[0];
+        const allMainClasses = await app.getMainClasses();
+        const testClassNames = ["MysqlTestApplication", "PetClinicIntegrationTests", "PostgresIntegrationTests"];
+        const testMainClasses = allMainClasses.filter(c => testClassNames.some(name => c.mainClass.endsWith(`.${name}`)));
+        assert.strictEqual(testMainClasses.length, testClassNames.length, "All test main classes should be resolved.");
+
+        try {
+            app.mainClasses = testMainClasses;
+            assert.strictEqual(
+                await app.getLaunchableMainClasses(),
+                testMainClasses,
+                "The original list should be returned when every main class is test-scoped."
+            );
+        } finally {
+            app.mainClasses = allMainClasses;
+        }
+    }).timeout(300 * 1000 /** ms */);
+
     test("Can view dynamic beans and mappings", async function() {
         // Skip on CI — launching the app is unreliable in headless environments
         // (wmic ENOENT on Windows Server 2025, debug session failures on Linux/macOS).

--- a/test/suite/extension.test.ts
+++ b/test/suite/extension.test.ts
@@ -1,6 +1,7 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license.
 import * as assert from "assert";
+import * as path from "path";
 import * as vscode from "vscode";
 import { AppState } from "../../src/BootApp";
 import { initSymbols } from "../../src/controllers/SymbolsController";
@@ -69,6 +70,30 @@ suite("Extension Test Suite", () => {
         assert.strictEqual(openedEditor?.selection.anchor.character, 1, "The definition of CrashController should be at character 1.");
     }).timeout(300 * 1000 /** ms */);
 
+    test("Should not offer main classes from test source folders", async () => {
+        let apps = dashboard.appsProvider.manager.getAppList();
+        while (apps.length === 0) {
+            console.log("waiting until the app list is populated");
+            await sleep(5 * 1000 /** ms */);
+            apps = dashboard.appsProvider.manager.getAppList();
+        }
+        const app = apps[0];
+
+        // petclinic declares a main method in PetClinicApplication plus three more in
+        // src/test/java (MysqlTestApplication, PetClinicIntegrationTests, PostgresIntegrationTests).
+        const allMainClasses = await app.getMainClasses();
+        const testMainClasses = allMainClasses.filter(c => c.filePath.includes(path.join("src", "test", "java")));
+        assert.ok(testMainClasses.length > 0, `There should be main classes in test source folders, but got ${JSON.stringify(allMainClasses)}.`);
+
+        // Only the one in src/main/java is a launch candidate. https://github.com/microsoft/vscode-spring-boot-dashboard/issues/420
+        const launchable = await app.getLaunchableMainClasses();
+        assert.deepStrictEqual(
+            launchable.map(c => c.mainClass),
+            ["org.springframework.samples.petclinic.PetClinicApplication"],
+            "Only the main class in src/main/java should be launchable."
+        );
+    }).timeout(300 * 1000 /** ms */);
+
     test("Can view dynamic beans and mappings", async function() {
         // Skip on CI — launching the app is unreliable in headless environments
         // (wmic ENOENT on Windows Server 2025, debug session failures on Linux/macOS).
@@ -81,8 +106,8 @@ suite("Extension Test Suite", () => {
         assert.strictEqual(apps.length, 1, "There are 1 app in the app list.");
         const app = apps[0];
 
-        // Filter to PetClinicApplication to avoid QuickPick when multiple main classes exist
-        app.mainClasses = app.mainClasses?.filter(c => c.mainClass.includes("PetClinicApplication"));
+        // No QuickPick is expected: petclinic's other main classes all live in test
+        // source folders, so PetClinicApplication is the only launch candidate.
         await vscode.commands.executeCommand("spring-boot-dashboard.localapp.run", app);
         while (app.state !== AppState.RUNNING) {
             await sleep(5 * 1000 /** ms */);

--- a/test/suite/extension.test.ts
+++ b/test/suite/extension.test.ts
@@ -27,7 +27,7 @@ suite("Extension Test Suite", () => {
         assert.strictEqual(await isAlive(process.pid, async () => { throw error; }), undefined);
     });
 
-    test("Treats two-dot-prefixed directories as source-folder children", () => {
+    test("Treats two-dot-prefixed directories as source-folder children", async () => {
         const testSourceFolder = path.resolve("workspace", "src", "test");
         const mainClasses = [
             {
@@ -54,8 +54,80 @@ suite("Extension Test Suite", () => {
         };
 
         assert.deepStrictEqual(
-            excludeTestMainClasses(mainClasses, classpath).map(c => c.mainClass),
+            (await excludeTestMainClasses(mainClasses, classpath, async () => false)).map(c => c.mainClass),
             ["example.OutsideApplication"]
+        );
+    });
+
+    test("Classifies main classes when linked source paths use different filesystem identities", async () => {
+        const linkedTestMain = {
+            mainClass: "example.LinkedTestApplication",
+            projectName: "example",
+            filePath: path.resolve("external", "linked-test", "example", "LinkedTestApplication.java")
+        };
+        const productionMain = {
+            mainClass: "example.Application",
+            projectName: "example",
+            filePath: path.resolve("workspace", "project", "src", "main", "java", "example", "Application.java")
+        };
+        const classpath = {
+            entries: [
+                {
+                    kind: "source",
+                    path: path.resolve("workspace", "project", "linked-test"),
+                    outputFolder: "",
+                    sourceContainerUrl: "",
+                    javadocContainerUrl: "",
+                    isSystem: false,
+                    isTest: true
+                },
+                {
+                    kind: "source",
+                    path: path.resolve("workspace", "project", "src", "main", "java"),
+                    outputFolder: "",
+                    sourceContainerUrl: "",
+                    javadocContainerUrl: "",
+                    isSystem: false,
+                    isTest: false
+                }
+            ]
+        };
+        const classifiedPaths: string[] = [];
+
+        const launchable = await excludeTestMainClasses(
+            [linkedTestMain, productionMain],
+            classpath,
+            async filePath => {
+                classifiedPaths.push(filePath);
+                return filePath === linkedTestMain.filePath;
+            }
+        );
+
+        assert.deepStrictEqual(launchable.map(c => c.mainClass), ["example.Application"]);
+        assert.deepStrictEqual(classifiedPaths, [linkedTestMain.filePath]);
+    });
+
+    test("Keeps unmatched main classes when test-file classification fails", async () => {
+        const mainClasses = [{
+            mainClass: "example.Application",
+            projectName: "example",
+            filePath: path.resolve("external", "src", "example", "Application.java")
+        }];
+        const classpath = {
+            entries: [{
+                kind: "source",
+                path: path.resolve("workspace", "project", "src", "test"),
+                outputFolder: "",
+                sourceContainerUrl: "",
+                javadocContainerUrl: "",
+                isSystem: false,
+                isTest: true
+            }]
+        };
+
+        assert.deepStrictEqual(
+            await excludeTestMainClasses(mainClasses, classpath, async () => { throw new Error("Command unavailable"); }),
+            mainClasses
         );
     });
 
@@ -134,6 +206,21 @@ suite("Extension Test Suite", () => {
             launchable.map(c => c.mainClass),
             ["org.springframework.samples.petclinic.PetClinicApplication"],
             "Only the main class in src/main/java should be launchable."
+        );
+
+        // A linked source root can be reported using its logical workspace path,
+        // while resolveMainClass reports files using the linked target's physical path.
+        const mismatchedClasspath = {
+            ...app.classpath,
+            entries: app.classpath.entries.map(cpe => cpe.kind === "source" && cpe.isTest
+                ? { ...cpe, path: path.resolve("logical-workspace", "linked-test-source") }
+                : cpe)
+        };
+        const launchableWithMismatchedPaths = await excludeTestMainClasses(allMainClasses, mismatchedClasspath);
+        assert.deepStrictEqual(
+            launchableWithMismatchedPaths.map(c => c.mainClass),
+            ["org.springframework.samples.petclinic.PetClinicApplication"],
+            "JDT should classify test main classes when source-root and file paths use different identities."
         );
     }).timeout(300 * 1000 /** ms */);
 


### PR DESCRIPTION
`vscode.java.resolveMainClass` searches every source folder of a project, so a `@SpringBootApplication` class copied into `src/test/java` — a common pattern for integration tests — was offered as an additional launch candidate. Running an app then popped up a quick pick asking the user to choose between the real main class and one that is irrelevant to launch.

Filter those out by matching each resolved main class against the test source folders of the project's classpath. The Spring Tools classpath listener already reports `isTest` for each source entry (set from `IClasspathEntry.isTest()`), so ordinary source roots are handled locally. For an unmatched path, such as an Eclipse linked source whose classpath entry and resolved file use logical and physical identities, the dashboard asks JDT LS `java.project.isTestFile` to classify the file. Classification failures retain the candidate so Run and Debug remain available.

The unfiltered list stays available via `getMainClasses()` so that live processes launched from a test main class are still associated with their app. When every main class sits in a test source folder, the filter falls back to the full list to keep such a project launchable.

Closes #420