### PR TITLE
ci: Use scoped VSCE package in ADO pipelines

### DIFF
--- a/.azp/VSCode-Spring-Boot-Dashboard-CI.yml
+++ b/.azp/VSCode-Spring-Boot-Dashboard-CI.yml
@@ -72,7 +72,7 @@ extends:
               - task: CmdLine@2
                 displayName: Command Line Script
                 inputs:
-                  script: npx vsce@latest package
+                  script: npx @vscode/vsce@latest package
               - task: CopyFiles@2
                 displayName: 'Copy Files to: $(Build.ArtifactStagingDirectory)'
                 inputs:

--- a/.azp/VSCode-Spring-Boot-Dashboard-Nightly.yml
+++ b/.azp/VSCode-Spring-Boot-Dashboard-Nightly.yml
@@ -101,7 +101,7 @@ extends:
               - task: CmdLine@2
                 displayName: VSCE package --pre-release
                 inputs:
-                  script: npx vsce@latest package --pre-release -o extension.vsix
+                  script: npx @vscode/vsce@latest package --pre-release -o extension.vsix
               - script: npm run test
                 displayName: npm run test
                 enabled: False

--- a/.azp/VSCode-Spring-Boot-Dashboard-RC.yml
+++ b/.azp/VSCode-Spring-Boot-Dashboard-RC.yml
@@ -89,7 +89,7 @@ extends:
               - task: CmdLine@2
                 displayName: VSCE package
                 inputs:
-                  script: npx vsce@latest package -o extension.vsix
+                  script: npx @vscode/vsce@latest package -o extension.vsix
               ### Copy files for APIScan
               - task: CopyFiles@2
                 displayName: "Copy Files for APIScan"


### PR DESCRIPTION
## Summary
- replace the deprecated `vsce` package with `@vscode/vsce` for extension packaging
- update the CI, Nightly, and RC pipelines
- align packaging with the existing scoped VSCE manifest generation step

## Context
Nightly builds have repeatedly failed while `npx vsce@latest` dynamically installs the deprecated `vsce@2.15.0` package. Using the maintained scoped package avoids that legacy install path while continuing to resolve the latest version available to the configured registry.