### PR TITLE
chore(deps): limit npm version updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,6 +9,9 @@ updates:
     directory: "/" # Location of package manifests
     schedule:
       interval: "daily"
+    ignore:
+      - dependency-name: "*"
+        update-types: ["version-update:semver-major"]
     # CI restores packages from the Central Feed Service, which withholds
     # upstream versions until they are roughly a week old (measured at ~6.8
     # days; both the packument entry and the tarball return 404 before then).
@@ -24,5 +27,8 @@ updates:
         patterns: ["*"]
     schedule:
       interval: "weekly"
+    ignore:
+      - dependency-name: "*"
+        update-types: ["version-update:semver-major"]
     cooldown:
-      default-days: 7
+      default-days: 10

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -27,8 +27,5 @@ updates:
         patterns: ["*"]
     schedule:
       interval: "weekly"
-    ignore:
-      - dependency-name: "*"
-        update-types: ["version-update:semver-major"]
     cooldown:
-      default-days: 10
+      default-days: 7


### PR DESCRIPTION
## Summary

Update only the npm entry in [Dependabot configuration](https://github.com/microsoft/vscode-spring-boot-dashboard/blob/974092615e423aa4234f285d7fedb2c83d973547/.github/dependabot.yml): ignore `version-update:semver-major` for `dependency-name: "*"`, allowing routine minor and patch updates only.

The existing cooldowns are unchanged from the original base: **npm keeps 10 days; GitHub Actions keeps 7 days**. The 10-day cooldown applies to all dependencies in the npm entry only, not across ecosystems. npm retains its daily schedule. The GitHub Actions entry is restored exactly to its original weekly schedule, wildcard group, 7-day cooldown, and no ignore rule.

Security settings remain unchanged. Cooldowns measure release age and apply only to version updates, not security updates.

## Validation

Parsed YAML with the installed `js-yaml` dependency: the GitHub Actions entry exactly matches the original base; npm retains its major-version ignore and 10-day cooldown; the complete configuration differs from the original base only by npm's ignore rule. Only `.github/dependabot.yml` changed.

Earlier local validation, with source and dependency files unchanged: `npm run prepublish` passed after a process-local Windows Maven-wrapper PATH correction, and `CI=true npm test` passed (8 passing, 1 existing skip). The normal `npm test` run had 8 passing and an unrelated 300-second timeout in the dynamic beans/mappings app-launch test, which the existing suite skips in CI.